### PR TITLE
Service: drop unresponsive peers

### DIFF
--- a/radicle-node/src/service/message.rs
+++ b/radicle-node/src/service/message.rs
@@ -315,6 +315,23 @@ pub enum Message {
     /// Gossip announcement. These messages are relayed to peers, and filtered
     /// using [`Message::Subscribe`].
     Announcement(Announcement),
+
+    /// Ask a connected peer for a Pong.
+    ///
+    /// Use to check if the remote peer is responsive or a side-effect free way to keep a
+    /// connection alive.
+    Ping {
+        /// The desired response length
+        ponglen: u16,
+        /// The ping payload.
+        zeroes: ZeroBytes,
+    },
+
+    /// Response to `Ping` message.
+    Pong {
+        /// The pong payload.
+        zeroes: ZeroBytes,
+    },
 }
 
 impl Message {
@@ -373,7 +390,26 @@ impl fmt::Debug for Message {
             Self::Announcement(Announcement { node, message, .. }) => {
                 write!(f, "Announcement({}, {:?})", node, message)
             }
+            Self::Ping { ponglen, zeroes } => write!(f, "Ping({ponglen}, {:?})", zeroes),
+            Self::Pong { zeroes } => write!(f, "Pong({:?})", zeroes),
         }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ZeroBytes(u16);
+
+impl ZeroBytes {
+    pub fn new(arg: u16) -> Self {
+        ZeroBytes(arg)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.into()
     }
 }
 

--- a/radicle-node/src/test/arbitrary.rs
+++ b/radicle-node/src/test/arbitrary.rs
@@ -8,7 +8,7 @@ use crate::prelude::{Id, NodeId, Refs, Timestamp};
 use crate::service::filter::{Filter, FILTER_SIZE_L, FILTER_SIZE_M, FILTER_SIZE_S};
 use crate::service::message::{
     Address, Announcement, Envelope, InventoryAnnouncement, Message, NodeAnnouncement,
-    RefsAnnouncement, Subscribe,
+    RefsAnnouncement, Subscribe, ZeroBytes,
 };
 use crate::wire::message::MessageType;
 
@@ -45,6 +45,8 @@ impl Arbitrary for Message {
                 MessageType::NodeAnnouncement,
                 MessageType::RefsAnnouncement,
                 MessageType::Subscribe,
+                MessageType::Ping,
+                MessageType::Pong,
             ])
             .unwrap();
 
@@ -93,6 +95,13 @@ impl Arbitrary for Message {
                 since: Timestamp::arbitrary(g),
                 until: Timestamp::arbitrary(g),
             }),
+            MessageType::Ping => Self::Ping {
+                ponglen: u16::arbitrary(g),
+                zeroes: ZeroBytes::arbitrary(g),
+            },
+            MessageType::Pong => Self::Pong {
+                zeroes: ZeroBytes::arbitrary(g),
+            },
             _ => unreachable!(),
         }
     }
@@ -113,5 +122,11 @@ impl Arbitrary for Address {
                 port: u16::arbitrary(g),
             }
         }
+    }
+}
+
+impl Arbitrary for ZeroBytes {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        ZeroBytes::new(u16::arbitrary(g))
     }
 }

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -22,7 +22,7 @@ use crate::storage::WriteStorage;
 use crate::test::arbitrary;
 use crate::test::signer::MockSigner;
 use crate::test::simulator;
-use crate::{Link, LocalTime};
+use crate::{Link, LocalDuration, LocalTime};
 
 /// Service instantiation used for testing.
 pub type Service<S, G> = service::Service<routing::Table, address::Book, S, G>;
@@ -249,6 +249,11 @@ where
             &remote,
             Message::init(peer.node_id(), peer.config().listen.clone(), git),
         );
+    }
+
+    pub fn elapse(&mut self, duration: LocalDuration) {
+        self.clock().elapse(duration);
+        self.service.wake();
     }
 
     /// Drain outgoing messages sent from this peer to the remote address.


### PR DESCRIPTION
Use pings to check connection health with network peers and drop them if they prove unresponsive.