### PR TITLE
radicle: namespace peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,12 +216,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -287,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-compact"
-version = "1.0.12"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25036262e9b9c81fe4c6decb438f753f66a8f06aac5dbe9eb2b28355c85c3f5"
+checksum = "bee9df587982575886a8682edcee11877894349a805f25629c27f63abe3e9ae8"
 dependencies = [
  "ct-codecs",
  "getrandom",
@@ -417,14 +416,13 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -466,9 +464,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
@@ -502,9 +500,9 @@ checksum = "478ee9e62aaeaf5b140bd4138753d1f109765488581444218d3ddda43234f3e8"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libgit2-sys"
@@ -641,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "olpc-cjson"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ca49fe685014bbf124ee547da94ed7bb65a6eb9dc9c4711773c081af96a39c"
+checksum = "87dc75cf72208cd853671c1abccc5d5d1e43b1e378dde67340ef933219a8c13c"
 dependencies = [
  "serde",
  "serde_json",
@@ -670,9 +668,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -728,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -910,18 +908,18 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1037,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1062,18 +1060,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/radicle-tools/src/rad-push.rs
+++ b/radicle-tools/src/rad-push.rs
@@ -8,7 +8,7 @@ fn main() -> anyhow::Result<()> {
     let profile = radicle::Profile::load()?;
     let (_, id) = radicle::rad::remote(&repo)?;
 
-    let output = radicle::git::run(&cwd, &["push", "rad"])?;
+    let output = radicle::git::run::<_, _, &str, &str>(&cwd, &["push", "rad"], None)?;
     println!("{}", output);
 
     let project = profile.storage.repository(id)?;

--- a/radicle/src/identity/project.rs
+++ b/radicle/src/identity/project.rs
@@ -358,8 +358,8 @@ impl Doc<Unverified> {
 
 impl<V> Doc<V> {
     pub fn head<R: ReadRepository>(remote: &RemoteId, repo: &R) -> Result<Oid, DocError> {
-        let head = &git::refname!("heads").join(&*git::refs::IDENTITY_BRANCH);
-        repo.reference_oid(remote, head).map_err(DocError::from)
+        let head = git::Qualified::from(git::lit::refs_heads(&*git::refs::IDENTITY_BRANCH));
+        repo.reference_oid(remote, &head).map_err(DocError::from)
     }
 }
 

--- a/radicle/src/test/storage.rs
+++ b/radicle/src/test/storage.rs
@@ -116,7 +116,7 @@ impl ReadRepository for MockRepository {
     fn reference(
         &self,
         _remote: &RemoteId,
-        _reference: &git::RefStr,
+        _reference: &git::Qualified,
     ) -> Result<git2::Reference, git_ext::Error> {
         todo!()
     }
@@ -124,7 +124,7 @@ impl ReadRepository for MockRepository {
     fn reference_oid(
         &self,
         _remote: &RemoteId,
-        _reference: &git::RefStr,
+        _reference: &git::Qualified,
     ) -> Result<git_ext::Oid, git_ext::Error> {
         todo!()
     }


### PR DESCRIPTION
The previous iteration of the storage layout for projects organised peer's subtrees by the `refs/remotes` category. This layout leads to problems when linking a working copy to the storage project. The fetch refspec would look something like:

  `fetch = +refs/remotes/abc/heads/*:refs/remotes/rad/*`

This works perfectly fine when running:

  git fetch rad

but will fail when one tries to specify:

  `git fetch rad main`

Instead, the command would need to be:

  `git fetch remotes/abc/heads/main`

This patch proposes to move the use of `refs/namespaces` for each peer. The layout looks similar in that each peer has a subtree, but instead it is under `refs/namespaces/<peer>/refs/...`.

The previous refspec would look more familiar in its new form:

  `fetch = +refs/heads/*:refs/remotes/rad/*`

With this in place running:

  `git --namespace=abc rad main`

Will work as expected and place the reference under `refs/remotes/rad/main`. Similary, `git --namespace=abc push` will work as expected.

Another benefit of this approach is that the use of namespacing means that a tag is pushed it will be placed under the respective namespace rather than in the global `refs/tags` category.

The actual implementation needed to work around the fact that `git2`/`libgit2` does not have any options for fetching or pushing using namespaces. The working copy code uses processes to shell out to `git` for namespacing needs.