### PR TITLE
SSH: support encoding/decoding armored signatures

### DIFF
--- a/radicle-ssh/src/agent/client.rs
+++ b/radicle-ssh/src/agent/client.rs
@@ -262,7 +262,7 @@ impl<S: ClientStream> AgentClient<S> {
         // string                  data
         // uint32                  flags
 
-        let mut pk = Vec::new().into();
+        let mut pk = Buffer::default();
         let n = public.write(&mut pk);
         let total = 1 + n + 4 + data.len() + 4;
 
@@ -296,7 +296,7 @@ impl<S: ClientStream> AgentClient<S> {
     where
         K: Public,
     {
-        let mut pk = Vec::new().into();
+        let mut pk: Buffer = Vec::new().into();
         let n = public.write(&mut pk);
         let total = 1 + n;
 

--- a/radicle-ssh/src/key.rs
+++ b/radicle-ssh/src/key.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 
-use crate::encoding::{Buffer, Cursor};
+use crate::encoding::{Buffer, Cursor, Encoding};
 
 /// A public SSH key.
 pub trait Public: Sized {
     type Error: Error + Send + Sync + 'static;
 
     /// Write the public key to the given buffer, in SSH "blob" format.
-    fn write(&self, buf: &mut Buffer) -> usize;
+    fn write<E: Encoding>(&self, buf: &mut E) -> usize;
     /// Read the public key from the given reader.
     fn read(reader: &mut Cursor) -> Result<Option<Self>, Self::Error>;
 }


### PR DESCRIPTION
Armored signatures are used by Git for signing commits.  Support reading writing these signatures by implementing a new trait to read and write to the SSH format.