### PR TITLE
radicle: depend on radicle-git published crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,8 @@ dependencies = [
 [[package]]
 name = "git-ref-format"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d819e0a29c3201eb3373f9371be2bf821437979791ff07fe23a40ed8adadcfc3"
 dependencies = [
  "git-ref-format-core",
  "git-ref-format-macro",
@@ -345,7 +346,8 @@ dependencies = [
 [[package]]
 name = "git-ref-format-core"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6937508983bd6ed558a64caa8b3ca6bd46fdff8be1389a961f9ddf7e0baddee5"
 dependencies = [
  "serde",
  "thiserror",
@@ -354,7 +356,8 @@ dependencies = [
 [[package]]
 name = "git-ref-format-macro"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66434445c9d45a85a9186a76770b1f80a44fdf8ed34fb6d4e3d12c5b9fc942ef"
 dependencies = [
  "git-ref-format-core",
  "proc-macro-error",
@@ -377,16 +380,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -506,30 +507,14 @@ checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.14.0+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
 dependencies = [
  "cc",
  "libc",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -661,25 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,7 +768,8 @@ dependencies = [
 [[package]]
 name = "radicle-git-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0906d0de75de1e19d595b9fa2a8a1478a8d75e057399e9795ffbe9b6864be4c"
 dependencies = [
  "git-ref-format",
  "git2",
@@ -854,7 +821,8 @@ dependencies = [
 [[package]]
 name = "radicle-std-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db20136bbc9ae63f3fec8e5a6c369f4902fac2244501b5dfc6d668e43475aaa4"
 
 [[package]]
 name = "radicle-tools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,6 @@
 [workspace]
 members = ["radicle", "radicle-node", "radicle-tools", "radicle-ssh"]
 
-[patch.crates-io.radicle-git-ext]
-git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
-
-[patch.crates-io.git-ref-format]
-git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
-
 [patch.crates-io.nakamoto-net]
 git = "https://github.com/cloudhead/nakamoto"
 rev = "90cc3eac67aa5cfd5f42cf7cb1e2b155af3214fb"

--- a/radicle/Cargo.toml
+++ b/radicle/Cargo.toml
@@ -17,7 +17,6 @@ crossbeam-channel = { version = "0.5.6" }
 ed25519-compact = { version = "1.0.12", features = ["pem"] }
 fastrand = { version = "1.8.0" }
 git-ref-format = { version = "0", features = ["serde", "macro"] }
-git2 = { version = "0.13" }
 git-url = { version = "0.3.5", features = ["serde1"] }
 multibase = { version = "0.9.1" }
 log = { version = "0.4.17", features = ["std"] }
@@ -33,6 +32,11 @@ nonempty = { version = "0.8.0", features = ["serialize"] }
 tempfile = { version = "3.3.0" }
 thiserror = { version = "1" }
 zeroize = { version = "1.5.7" }
+
+[dependencies.git2]
+version = "0.15.0"
+default-features = false
+features = ["vendored-libgit2"]
 
 [dependencies.radicle-ssh]
 path = "../radicle-ssh"

--- a/radicle/src/git.rs
+++ b/radicle/src/git.rs
@@ -72,7 +72,7 @@ pub mod refs {
         /// Create the [`Namespaced`] `branch` under the `remote` namespace, i.e.
         /// `refs/namespaces/<remote>/refs/heads/<branch>`
         pub fn branch<'a>(remote: &RemoteId, branch: &RefStr) -> Namespaced<'a> {
-            Qualified::from(git_ref_format::lit::refs_heads(branch)).add_namespace(remote.into())
+            Qualified::from(git_ref_format::lit::refs_heads(branch)).with_namespace(remote.into())
         }
 
         /// Get the branch used to track project information.
@@ -112,7 +112,7 @@ pub mod refs {
 pub fn remote_refs(url: &Url) -> Result<HashMap<RemoteId, Refs>, ListRefsError> {
     let url = url.to_string();
     let mut remotes = HashMap::default();
-    let mut remote = git2::Remote::create_detached(&url)?;
+    let mut remote = git2::Remote::create_detached(url)?;
 
     remote.connect(git2::Direction::Fetch)?;
 
@@ -134,7 +134,7 @@ where
     T::Err: std::error::Error + Send + Sync + 'static,
 {
     let input = format::RefStr::try_from_str(s)?;
-    match input.namespaced() {
+    match input.to_namespaced() {
         None => Err(RefError::MissingNamespace(input.to_owned())),
         Some(ns) => {
             let id = ns

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -417,7 +417,7 @@ impl ReadRepository for Repository {
         remote: &RemoteId,
         name: &git::Qualified,
     ) -> Result<git2::Reference, git::Error> {
-        let name = name.add_namespace(remote.into());
+        let name = name.with_namespace(remote.into());
         self.backend.find_reference(&name).map_err(git::Error::from)
     }
 

--- a/radicle/src/storage/refs.rs
+++ b/radicle/src/storage/refs.rs
@@ -297,7 +297,7 @@ impl SignedRefs<Verified> {
             }
         }
 
-        let sigref = sigref.add_namespace(remote.into());
+        let sigref = sigref.with_namespace(remote.into());
         let author = repo.raw().signature()?;
         let commit = repo.raw().commit(
             Some(&sigref),


### PR DESCRIPTION
The `git-ref-format`[[0]] and `radicle-git-ext`[[1]] crates are now published to crates.io.

Switch the dependency to rely on them. This also required to update the `git2` dependency to `0.15.0` as well as using the `vendored-libgit2` feature -- avoiding the openssl dependency too.

Fixes #27 

[0]: https://crates.io/crates/git-ref-format
[1]: https://crates.io/crates/radicle-git-ext