### PR TITLE
node: follow up on session renaming

### DIFF
--- a/radicle-node/src/service/reactor.rs
+++ b/radicle-node/src/service/reactor.rs
@@ -4,7 +4,7 @@ use std::net;
 use log::*;
 
 use crate::prelude::*;
-use crate::service::peer::Session;
+use crate::service::session::Session;
 
 use super::message::{Announcement, AnnouncementMessage};
 

--- a/radicle-node/src/test/tests.rs
+++ b/radicle-node/src/test/tests.rs
@@ -10,7 +10,6 @@ use crate::prelude::{LocalDuration, Timestamp};
 use crate::service::config::*;
 use crate::service::filter::Filter;
 use crate::service::message::*;
-use crate::service::peer::*;
 use crate::service::reactor::Io;
 use crate::service::ServiceState as _;
 use crate::service::*;
@@ -280,7 +279,7 @@ fn test_inventory_relay_bad_timestamp() {
     );
     assert_matches!(
         alice.outbox().next(),
-        Some(Io::Disconnect(addr, DisconnectReason::Error(SessionError::InvalidTimestamp(t))))
+        Some(Io::Disconnect(addr, DisconnectReason::Error(session::Error::InvalidTimestamp(t))))
         if addr == bob.addr() && t == timestamp
     );
 }


### PR DESCRIPTION
Rename the module to session from peer to be consistent with recent renaming of the type from Peer to Session.