### PR TITLE
Remove `Envelope` type

### DIFF
--- a/radicle-node/src/decoder.rs
+++ b/radicle-node/src/decoder.rs
@@ -1,14 +1,14 @@
 use std::io;
 use std::marker::PhantomData;
 
-use crate::service::message::Envelope;
+use crate::service::message::Message;
 use crate::wire;
 
 /// Message stream decoder.
 ///
 /// Used to for example turn a byte stream into network messages.
 #[derive(Debug)]
-pub struct Decoder<D = Envelope> {
+pub struct Decoder<D = Message> {
     unparsed: Vec<u8>,
     item: PhantomData<D>,
 }

--- a/radicle-node/src/lib.rs
+++ b/radicle-node/src/lib.rs
@@ -21,7 +21,7 @@ pub mod prelude {
     pub use crate::identity::{Did, Id};
     pub use crate::service::filter::Filter;
     pub use crate::service::message::Address;
-    pub use crate::service::{DisconnectReason, Envelope, Event, Message, Network, NodeId};
+    pub use crate::service::{DisconnectReason, Event, Message, Network, NodeId};
     pub use crate::storage::refs::Refs;
     pub use crate::storage::WriteStorage;
     pub use crate::{LocalDuration, LocalTime};

--- a/radicle-node/src/service/config.rs
+++ b/radicle-node/src/service/config.rs
@@ -3,7 +3,7 @@ use crate::git;
 use crate::git::Url;
 use crate::identity::{Id, PublicKey};
 use crate::service::filter::Filter;
-use crate::service::message::{Address, Envelope, Message};
+use crate::service::message::Address;
 
 /// Peer-to-peer network.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
@@ -11,22 +11,6 @@ pub enum Network {
     #[default]
     Main,
     Test,
-}
-
-impl Network {
-    pub fn magic(&self) -> u32 {
-        match self {
-            Self::Main => 0x819b43d9,
-            Self::Test => 0x717ebaf8,
-        }
-    }
-
-    pub fn envelope(&self, msg: Message) -> Envelope {
-        Envelope {
-            magic: self.magic(),
-            msg,
-        }
-    }
 }
 
 /// Project tracking policy.

--- a/radicle-node/src/service/message.rs
+++ b/radicle-node/src/service/message.rs
@@ -12,15 +12,6 @@ use crate::service::{NodeId, Timestamp, PROTOCOL_VERSION};
 use crate::storage::refs::Refs;
 use crate::wire;
 
-/// Message envelope. All messages sent over the network are wrapped in this type.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Envelope {
-    /// Network magic constant. Used to differentiate networks.
-    pub magic: u32,
-    /// The message payload.
-    pub msg: Message,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 // TODO: We should check the length and charset when deserializing.
 pub struct Hostname(String);

--- a/radicle-node/src/service/peer.rs
+++ b/radicle-node/src/service/peer.rs
@@ -37,8 +37,6 @@ pub enum SessionState {
 
 #[derive(thiserror::Error, Debug)]
 pub enum SessionError {
-    #[error("wrong network constant in message: {0}")]
-    WrongMagic(u32),
     #[error("wrong protocol version in message: {0}")]
     WrongVersion(u32),
     #[error("invalid announcement timestamp: {0}")]

--- a/radicle-node/src/test/arbitrary.rs
+++ b/radicle-node/src/test/arbitrary.rs
@@ -7,7 +7,7 @@ use crate::crypto;
 use crate::prelude::{Id, NodeId, Refs, Timestamp};
 use crate::service::filter::{Filter, FILTER_SIZE_L, FILTER_SIZE_M, FILTER_SIZE_S};
 use crate::service::message::{
-    Address, Announcement, Envelope, InventoryAnnouncement, Message, NodeAnnouncement, Ping,
+    Address, Announcement, InventoryAnnouncement, Message, NodeAnnouncement, Ping,
     RefsAnnouncement, Subscribe, ZeroBytes,
 };
 use crate::wire::message::MessageType;
@@ -25,15 +25,6 @@ impl Arbitrary for Filter {
             bytes[index] = u8::arbitrary(g);
         }
         Self::from(BloomFilter::from(bytes))
-    }
-}
-
-impl Arbitrary for Envelope {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        Self {
-            magic: u32::arbitrary(g),
-            msg: Message::arbitrary(g),
-        }
     }
 }
 

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -154,8 +154,7 @@ where
     }
 
     pub fn receive(&mut self, peer: &net::SocketAddr, msg: Message) {
-        self.service
-            .received_message(peer, self.config().network.envelope(msg));
+        self.service.received_message(peer, msg);
     }
 
     pub fn inventory_announcement(&self) -> Message {
@@ -262,8 +261,8 @@ where
         let mut msgs = Vec::new();
 
         self.service.reactor().outbox().retain(|o| match o {
-            Io::Write(a, envelopes) if a == remote => {
-                msgs.extend(envelopes.iter().map(|e| e.msg.clone()));
+            Io::Write(a, messages) if a == remote => {
+                msgs.extend(messages.clone());
                 false
             }
             _ => true,

--- a/radicle-node/src/test/simulator.rs
+++ b/radicle-node/src/test/simulator.rs
@@ -17,7 +17,7 @@ use nakamoto_net::{Link, LocalDuration, LocalTime};
 
 use crate::crypto::Signer;
 use crate::service::reactor::Io;
-use crate::service::{DisconnectReason, Envelope, Event};
+use crate::service::{DisconnectReason, Event, Message};
 use crate::storage::WriteStorage;
 use crate::test::peer::Service;
 
@@ -64,7 +64,7 @@ pub enum Input {
         Rc<nakamoto::DisconnectReason<DisconnectReason>>,
     ),
     /// Received a message from a remote peer.
-    Received(net::SocketAddr, Vec<Envelope>),
+    Received(net::SocketAddr, Vec<Message>),
     /// Used to advance the state machine after some wall time has passed.
     Wake,
 }

--- a/radicle-node/src/wire/message.rs
+++ b/radicle-node/src/wire/message.rs
@@ -296,26 +296,6 @@ impl wire::Decode for Message {
     }
 }
 
-impl wire::Encode for Envelope {
-    fn encode<W: std::io::Write + ?Sized>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
-        let mut n = 0;
-
-        n += self.magic.encode(writer)?;
-        n += self.msg.encode(writer)?;
-
-        Ok(n)
-    }
-}
-
-impl wire::Decode for Envelope {
-    fn decode<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<Self, wire::Error> {
-        let magic = u32::decode(reader)?;
-        let msg = Message::decode(reader)?;
-
-        Ok(Self { magic, msg })
-    }
-}
-
 impl wire::Encode for Address {
     fn encode<W: std::io::Write + ?Sized>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         let mut n = 0;
@@ -404,18 +384,10 @@ mod tests {
         );
     }
 
-    #[quickcheck]
-    fn prop_envelope_encode_decode(envelope: Envelope) {
-        assert_eq!(
-            wire::deserialize::<Envelope>(&wire::serialize(&envelope)).unwrap(),
-            envelope
-        );
-    }
-
     #[test]
-    fn prop_envelope_decoder() {
-        fn property(items: Vec<Envelope>) {
-            let mut decoder = Decoder::<Envelope>::new(8);
+    fn prop_message_decoder() {
+        fn property(items: Vec<Message>) {
+            let mut decoder = Decoder::<Message>::new(8);
 
             for item in &items {
                 item.encode(&mut decoder).unwrap();
@@ -427,7 +399,7 @@ mod tests {
 
         quickcheck::QuickCheck::new()
             .gen(quickcheck::Gen::new(16))
-            .quickcheck(property as fn(items: Vec<Envelope>));
+            .quickcheck(property as fn(items: Vec<Message>));
     }
 
     #[quickcheck]


### PR DESCRIPTION
This type that was wrapping `Message` isn't very useful here. If we decide that we do need something like that, it's best handled one layer below.

Signed-off-by: Alexis Sellier <alexis@radicle.xyz>