### PR TITLE
Set repository canonical refs

### DIFF
--- a/radicle-remote-helper/src/lib.rs
+++ b/radicle-remote-helper/src/lib.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use radicle::crypto::{PublicKey, Signer};
 use radicle::node::Handle;
 use radicle::ssh;
-use radicle::storage::{ReadRepository, WriteStorage};
+use radicle::storage::{ReadRepository, WriteRepository, WriteStorage};
 
 /// The service invoked by git on the remote repository, during a push.
 const GIT_RECEIVE_PACK: &str = "git-receive-pack";
@@ -180,6 +180,7 @@ pub fn run(profile: radicle::Profile) -> Result<(), Box<dyn std::error::Error + 
                 if child.wait()?.success() {
                     if *service == GIT_RECEIVE_PACK {
                         profile.storage.sign_refs(&proj, &profile.signer)?;
+                        proj.set_head()?;
                         // Connect to local node and announce refs to the network.
                         // If our node is not running, we simply skip this step, as the
                         // refs will be announced eventually, when the node restarts.

--- a/radicle/src/identity/project.rs
+++ b/radicle/src/identity/project.rs
@@ -509,7 +509,7 @@ mod test {
         let oid = git2::Oid::from_str("2d52a53ce5e4f141148a5f770cfd3ead2d6a45b8").unwrap();
 
         let err = Doc::<Unverified>::head(&remote, &repo).unwrap_err();
-        assert!(dbg!(err).is_not_found());
+        assert!(err.is_not_found());
 
         let err = Doc::load_at(oid.into(), &repo).unwrap_err();
         assert!(err.is_not_found());

--- a/radicle/src/test/storage.rs
+++ b/radicle/src/test/storage.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use git_ref_format as fmt;
 use git_url::Url;
 use radicle_git_ext as git_ext;
 
@@ -85,6 +86,10 @@ impl ReadRepository for MockRepository {
         Ok(true)
     }
 
+    fn head(&self) -> Result<(Oid, fmt::Qualified), ProjectError> {
+        todo!()
+    }
+
     fn path(&self) -> &std::path::Path {
         todo!()
     }
@@ -150,6 +155,10 @@ impl WriteRepository for MockRepository {
     }
 
     fn raw(&self) -> &git2::Repository {
+        todo!()
+    }
+
+    fn set_head(&self) -> Result<Oid, ProjectError> {
         todo!()
     }
 }


### PR DESCRIPTION
We set the `HEAD` and eg. `refs/heads/master` refs when updating repositories, which allows users to easily clone with git.

For now, `HEAD` is chosen based on a unanimity quorum of delegates. This can be made more sophisticated in the future.

We've also had to ignore some refs during verification, since these have cropped in for eg. due to the staging copy clone and the changes included here.

Signed-off-by: Alexis Sellier <alexis@radicle.xyz>