### PR TITLE
rad-auth: allow running multiple times

### DIFF
--- a/radicle-tools/src/rad-auth.rs
+++ b/radicle-tools/src/rad-auth.rs
@@ -1,9 +1,16 @@
+use radicle::profile;
+use radicle::Profile;
+
 fn main() -> anyhow::Result<()> {
-    let keypair = radicle::crypto::KeyPair::generate();
-    radicle::crypto::ssh::agent::register(&keypair.sk)?;
-
-    let profile = radicle::Profile::init(keypair)?;
-
+    let profile = match Profile::load() {
+        Ok(v) => v,
+        Err(profile::Error::NotFound(_)) => {
+            let keypair = radicle::crypto::KeyPair::generate();
+            radicle::crypto::ssh::agent::register(&keypair.sk)?;
+            radicle::Profile::init(keypair)?
+        }
+        Err(err) => anyhow::bail!(err),
+    };
     println!("id: {}", profile.id());
     println!("home: {}", profile.home.display());
 

--- a/radicle/src/keystore.rs
+++ b/radicle/src/keystore.rs
@@ -58,15 +58,21 @@ impl UnsafeKeystore {
         Ok(())
     }
 
-    pub fn get(&self) -> Result<(PublicKey, SecretKey), Error> {
-        let public = fs::read(self.path.join("radicle.pub"))?;
+    pub fn get(&self) -> Result<Option<(PublicKey, SecretKey)>, Error> {
+        let public = self.path.join("radicle.pub");
+        let secret = self.path.join("radicle");
+        if !public.exists() && !secret.exists() {
+            return Ok(None);
+        }
+
+        let public = fs::read(public)?;
         let public = String::from_utf8(public)?;
         let public = PublicKey::from_pem(&public)?;
 
-        let secret = fs::read(self.path.join("radicle"))?;
+        let secret = fs::read(secret)?;
         let secret = String::from_utf8(secret)?;
         let secret = SecretKey::from_pem(&secret)?;
 
-        Ok((public, secret))
+        Ok(Some((public, secret)))
     }
 }


### PR DESCRIPTION
Instead of failing over when a key has been created, run as normal using the previously created profile.