### PR TITLE
Move `radicle/id` and `radicle/signature`

### DIFF
--- a/radicle/src/identity/project.rs
+++ b/radicle/src/identity/project.rs
@@ -31,9 +31,11 @@ pub struct Untrusted;
 #[derive(Clone, Copy, Debug)]
 pub struct Trusted;
 
+/// Path to the identity document in the identity branch.
 pub static PATH: Lazy<&Path> = Lazy::new(|| Path::new("radicle.json"));
-
+/// Maximum length of a string in the identity document.
 pub const MAX_STRING_LENGTH: usize = 255;
+/// Maximum number of a delegates in the identity document.
 pub const MAX_DELEGATES: usize = 255;
 
 #[derive(Error, Debug)]
@@ -148,11 +150,6 @@ impl Doc<Verified> {
         msg: &str,
         storage: &S,
     ) -> Result<(Id, git::Oid, S::Repository), DocError> {
-        // You can checkout this branch in your working copy with:
-        //
-        //      git fetch rad
-        //      git checkout -b radicle/id remotes/rad/radicle/id
-        //
         let (doc_oid, doc) = self.encode()?;
         let id = Id::from(doc_oid);
         let repo = storage.repository(id)?;
@@ -358,8 +355,8 @@ impl Doc<Unverified> {
 
 impl<V> Doc<V> {
     pub fn head<R: ReadRepository>(remote: &RemoteId, repo: &R) -> Result<Oid, DocError> {
-        let head = git::Qualified::from(git::lit::refs_heads(&*git::refs::IDENTITY_BRANCH));
-        repo.reference_oid(remote, &head).map_err(DocError::from)
+        repo.reference_oid(remote, &git::refs::storage::IDENTITY_BRANCH)
+            .map_err(DocError::from)
     }
 }
 

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -122,7 +122,7 @@ pub fn fork_remote<G: Signer, S: storage::WriteStorage>(
     // Creates or copies the following references:
     //
     // refs/remotes/<pk>/heads/master
-    // refs/remotes/<pk>/heads/radicle/id
+    // refs/remotes/<pk>/rad/id
     // refs/remotes/<pk>/tags/*
     // refs/remotes/<pk>/rad/signature
 

--- a/radicle/src/test/arbitrary.rs
+++ b/radicle/src/test/arbitrary.rs
@@ -152,7 +152,7 @@ impl Arbitrary for Refs {
             "heads/feature/1",
             "heads/feature/2",
             "heads/feature/3",
-            "heads/radicle/id",
+            "rad/id",
             "tags/v1.0",
             "tags/v2.0",
             "notes/1",


### PR DESCRIPTION
We move the identity branch out of `heads/` and to the old location:

    refs/rad/id

We move the signed refs branch to:

    refs/rad/sigrefs

Keeping both "special" branches under the same hierarchy makes things a bit easier to work with, and tells the user that they should be updated with special tooling.

We also revert to `rad/` because we no longer have the issue of having `rad/rad/id` when doing a checkout of the remote branch in a working copy.

Closes #22 