### PR TITLE
node: use method to access session's Node ID

### DIFF
--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -1126,13 +1126,7 @@ impl Sessions {
     }
 
     pub fn by_id(&self, id: &NodeId) -> Option<&Session> {
-        self.0.values().find(|p| {
-            if let session::State::Negotiated { id: _id, .. } = &p.state {
-                _id == id
-            } else {
-                false
-            }
-        })
+        self.0.values().find(|p| p.node_id() == Some(*id))
     }
 
     /// Iterator over fully negotiated peers.

--- a/radicle-node/src/service/session.rs
+++ b/radicle-node/src/service/session.rs
@@ -122,4 +122,11 @@ impl Session {
         }
         Ok(())
     }
+
+    pub fn node_id(&self) -> Option<NodeId> {
+        if let State::Negotiated { id, .. } = &self.state {
+            return Some(*id);
+        }
+        None
+    }
 }


### PR DESCRIPTION
Make accessing an important session value, the Node ID, as a method to Session.