### PR TITLE
node: keep healthy connection to network

### DIFF
--- a/radicle-node/src/main.rs
+++ b/radicle-node/src/main.rs
@@ -14,6 +14,7 @@ type Reactor = nakamoto_net_poll::Reactor<net::TcpStream>;
 struct Options {
     connect: Vec<Address>,
     listen: Vec<net::SocketAddr>,
+    external_addresses: Vec<Address>,
 }
 
 impl Options {
@@ -22,6 +23,7 @@ impl Options {
 
         let mut parser = lexopt::Parser::from_env();
         let mut connect = Vec::new();
+        let mut external_addresses = Vec::new();
         let mut listen = Vec::new();
 
         while let Some(arg) = parser.next()? {
@@ -34,6 +36,10 @@ impl Options {
                     let addr = parser.value()?.parse()?;
                     listen.push(addr);
                 }
+                Long("external-address") => {
+                    let addr = parser.value()?.parse()?;
+                    external_addresses.push(addr);
+                }
                 Long("help") => {
                     println!("usage: radicle-node [--connect <addr>]..");
                     process::exit(0);
@@ -41,7 +47,11 @@ impl Options {
                 _ => return Err(arg.unexpected()),
             }
         }
-        Ok(Self { connect, listen })
+        Ok(Self {
+            connect,
+            listen,
+            external_addresses,
+        })
     }
 }
 
@@ -66,6 +76,7 @@ fn main() -> anyhow::Result<()> {
     let config = client::Config {
         service: service::Config {
             connect: options.connect,
+            external_addresses: options.external_addresses,
             ..service::Config::default()
         },
         listen: options.listen,

--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -544,11 +544,11 @@ where
 
         debug!("Disconnected from {} ({})", ip, reason);
 
-        if let Some(peer) = self.sessions.get_mut(&ip) {
-            peer.state = session::State::Disconnected { since };
+        if let Some(session) = self.sessions.get_mut(&ip) {
+            session.state = session::State::Disconnected { since };
 
             // Attempt to re-connect to persistent peers.
-            if self.config.is_persistent(&address) && peer.attempts() < MAX_CONNECTION_ATTEMPTS {
+            if self.config.is_persistent(&address) && session.attempts() < MAX_CONNECTION_ATTEMPTS {
                 if reason.is_dial_err() {
                     return;
                 }
@@ -559,7 +559,11 @@ where
                 }
                 // TODO: Eventually we want a delay before attempting a reconnection,
                 // with exponential back-off.
-                debug!("Reconnecting to {} (attempts={})...", ip, peer.attempts());
+                debug!(
+                    "Reconnecting to {} (attempts={})...",
+                    ip,
+                    session.attempts()
+                );
 
                 // TODO: Try to reconnect only if the peer was attempted. A disconnect without
                 // even a successful attempt means that we're unlikely to be able to reconnect.

--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -566,8 +566,8 @@ where
 
                 self.reactor.connect(*addr);
             } else {
-                // TODO: Non-persistent peers should be removed from the
-                // map here or at some later point.
+                self.sessions.remove(&ip);
+                self.maintain_connections();
             }
         }
     }

--- a/radicle-node/src/service/config.rs
+++ b/radicle-node/src/service/config.rs
@@ -46,6 +46,8 @@ pub struct Config {
     /// Peers to connect to on startup.
     /// Connections to these peers will be maintained.
     pub connect: Vec<Address>,
+    /// Specify the node's public addresses
+    pub external_addresses: Vec<Address>,
     /// Peer-to-peer network.
     pub network: Network,
     /// Project tracking policy.
@@ -62,6 +64,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             connect: Vec::default(),
+            external_addresses: vec![],
             network: Network::default(),
             project_tracking: ProjectTracking::default(),
             remote_tracking: RemoteTracking::default(),

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -7,6 +7,7 @@ use std::ops::{Deref, DerefMut};
 use log::*;
 
 use crate::address;
+use crate::address::Store;
 use crate::clock::{RefClock, Timestamp};
 use crate::crypto::test::signer::MockSigner;
 use crate::crypto::Signer;
@@ -123,6 +124,26 @@ where
 
     pub fn address(&self) -> Address {
         simulator::Peer::addr(self).into()
+    }
+
+    pub fn import_addresses<P>(&mut self, peers: P)
+    where
+        P: AsRef<[Self]>,
+    {
+        let timestamp = self.timestamp();
+        for peer in peers.as_ref() {
+            let known_address = address::KnownAddress::new(peer.address(), address::Source::Peer);
+            self.service
+                .addresses_mut()
+                .insert(
+                    &peer.node_id(),
+                    radicle::node::Features::default(),
+                    peer.name,
+                    timestamp,
+                    Some(known_address),
+                )
+                .unwrap();
+        }
     }
 
     pub fn timestamp(&self) -> Timestamp {

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -75,7 +75,8 @@ where
         let mut rng = fastrand::Rng::new();
         let signer = MockSigner::new(&mut rng);
 
-        Self::config(name, Config::default(), ip, storage, signer, rng)
+        let addrs = address::Book::memory().unwrap();
+        Self::config(name, Config::default(), ip, storage, addrs, signer, rng)
     }
 }
 
@@ -89,13 +90,13 @@ where
         config: Config,
         ip: impl Into<net::IpAddr>,
         storage: S,
+        addrs: address::Book,
         signer: G,
         rng: fastrand::Rng,
     ) -> Self {
         let local_time = LocalTime::now();
         let clock = RefClock::from(local_time);
         let routing = routing::Table::memory().unwrap();
-        let addrs = address::Book::memory().unwrap();
         let service = Service::new(config, clock, routing, storage, addrs, signer, rng.clone());
         let ip = ip.into();
         let local_addr = net::SocketAddr::new(ip, rng.u16(..));


### PR DESCRIPTION
Check to keep a healthy connection to the Radicle network when a disconnect occurs (up to 30 seconds), or when a node disconnects.

Also:
 - Rename peer -> session
 - Update recorded sessions when disconnect is official.

References #25
