### PR TITLE
node: make tests in tests mod run

### DIFF
--- a/radicle-node/src/lib.rs
+++ b/radicle-node/src/lib.rs
@@ -8,6 +8,8 @@ pub mod service;
 pub mod sql;
 #[cfg(any(test, feature = "test"))]
 pub mod test;
+#[cfg(test)]
+pub mod tests;
 pub mod transport;
 pub mod wire;
 


### PR DESCRIPTION
Fix a problem from a recent commit which caused tests in the tests module not to run.

The list of modules in 'lib.rs' should use the 'tests' module's new location.