### PR TITLE
node: try using static Vector limits

### DIFF
--- a/radicle-node/src/bounded.rs
+++ b/radicle-node/src/bounded.rs
@@ -1,0 +1,86 @@
+use std::ops;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("invalid size: expected {expected}, got {actual}")]
+    InvalidSize { expected: usize, actual: usize },
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BoundedVec<T, const N: usize> {
+    v: Vec<T>,
+}
+
+impl<T, const N: usize> BoundedVec<T, N> {
+    pub fn new() -> Self {
+        BoundedVec { v: Vec::new() }
+    }
+
+    pub fn truncate(mut v: Vec<T>) -> Self {
+        v.truncate(N);
+        BoundedVec { v }
+    }
+
+    pub fn max() -> usize {
+        N
+    }
+
+    pub fn push(&mut self, item: T) -> Result<(), Error> {
+        if self.len() >= N {
+            return Err(Error::InvalidSize {
+                expected: N,
+                actual: N + 1,
+            });
+        }
+        self.v.push(item);
+        Ok(())
+    }
+
+    pub fn unbound(self) -> Vec<T> {
+        self.v
+    }
+
+    pub fn with_capacity(capacity: usize) -> Result<Self, Error> {
+        if capacity > N {
+            return Err(Error::InvalidSize {
+                expected: N,
+                actual: capacity,
+            });
+        }
+        Ok(Self {
+            v: Vec::with_capacity(capacity),
+        })
+    }
+}
+
+impl<T, const N: usize> ops::Deref for BoundedVec<T, N> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.v
+    }
+}
+
+impl<T, const N: usize> From<Option<T>> for BoundedVec<T, N> {
+    fn from(value: Option<T>) -> Self {
+        let v = match value {
+            None => vec![],
+            Some(v) => vec![v],
+        };
+        BoundedVec { v }
+    }
+}
+
+impl<T, const N: usize> TryFrom<Vec<T>> for BoundedVec<T, N> {
+    type Error = Error;
+
+    fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
+        if value.len() > N {
+            return Err(Error::InvalidSize {
+                expected: N,
+                actual: value.len(),
+            });
+        }
+        Ok(BoundedVec { v: value })
+    }
+}

--- a/radicle-node/src/lib.rs
+++ b/radicle-node/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod address;
+pub mod bounded;
 pub mod client;
 pub mod clock;
 pub mod control;
@@ -16,6 +17,7 @@ pub use nakamoto_net::{Io, Link, LocalDuration, LocalTime};
 pub use radicle::{collections, crypto, git, identity, node, profile, rad, storage};
 
 pub mod prelude {
+    pub use crate::bounded::BoundedVec;
     pub use crate::clock::Timestamp;
     pub use crate::crypto::hash::Digest;
     pub use crate::crypto::{PublicKey, Signature, Signer};

--- a/radicle-node/src/main.rs
+++ b/radicle-node/src/main.rs
@@ -21,7 +21,7 @@ struct Options {
 }
 
 impl Options {
-    fn from_env() -> Result<Self, lexopt::Error> {
+    fn from_env() -> Result<Self, anyhow::Error> {
         use lexopt::prelude::*;
 
         let mut parser = lexopt::Parser::from_env();
@@ -55,9 +55,17 @@ impl Options {
                     println!("usage: radicle-node [--connect <addr>]..");
                     process::exit(0);
                 }
-                _ => return Err(arg.unexpected()),
+                _ => anyhow::bail!(arg.unexpected()),
             }
         }
+
+        if external_addresses.len() > service::ADDRESS_LIMIT {
+            anyhow::bail!(
+                "external address limit ({}) exceeded",
+                service::ADDRESS_LIMIT,
+            )
+        }
+
         Ok(Self {
             connect,
             external_addresses,

--- a/radicle-node/src/service/config.rs
+++ b/radicle-node/src/service/config.rs
@@ -85,7 +85,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             connect: Vec::default(),
-            external_addresses: vec![],
+            external_addresses: Vec::default(),
             network: Network::default(),
             project_tracking: ProjectTracking::default(),
             remote_tracking: RemoteTracking::default(),

--- a/radicle-node/src/test/arbitrary.rs
+++ b/radicle-node/src/test/arbitrary.rs
@@ -4,7 +4,7 @@ use bloomy::BloomFilter;
 use quickcheck::Arbitrary;
 
 use crate::crypto;
-use crate::prelude::{Id, NodeId, Refs, Timestamp};
+use crate::prelude::{BoundedVec, Id, NodeId, Refs, Timestamp};
 use crate::service::filter::{Filter, FILTER_SIZE_L, FILTER_SIZE_M, FILTER_SIZE_S};
 use crate::service::message::{
     Address, Announcement, InventoryAnnouncement, Message, NodeAnnouncement, Ping,
@@ -45,7 +45,7 @@ impl Arbitrary for Message {
             MessageType::InventoryAnnouncement => Announcement {
                 node: NodeId::arbitrary(g),
                 message: InventoryAnnouncement {
-                    inventory: Vec::<Id>::arbitrary(g),
+                    inventory: BoundedVec::arbitrary(g),
                     timestamp: Timestamp::arbitrary(g),
                 }
                 .into(),
@@ -121,5 +121,16 @@ impl Arbitrary for Address {
 impl Arbitrary for ZeroBytes {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
         ZeroBytes::new(u16::arbitrary(g))
+    }
+}
+
+impl<T, const N: usize> Arbitrary for BoundedVec<T, N>
+where
+    T: Arbitrary + Eq,
+{
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let mut v: Vec<T> = Arbitrary::arbitrary(g);
+        v.truncate(N);
+        v.try_into().expect("size within bounds")
     }
 }

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -185,7 +185,8 @@ where
                 features: node::Features::SEED,
                 timestamp: self.timestamp(),
                 alias,
-                addresses: vec![net::SocketAddr::from((self.ip, service::DEFAULT_PORT)).into()],
+                addresses: Some(net::SocketAddr::from((self.ip, service::DEFAULT_PORT)).into())
+                    .into(),
                 nonce: 0,
             }
             .solve(),
@@ -214,7 +215,7 @@ where
         self.service.connected(remote, Link::Inbound);
         self.receive(
             &remote,
-            Message::init(peer.node_id(), vec![Address::from(remote)]),
+            Message::init(peer.node_id(), Some(Address::from(remote)).into()),
         );
 
         let mut msgs = self.messages(&remote);
@@ -257,7 +258,14 @@ where
 
         self.receive(
             &remote,
-            Message::init(peer.node_id(), peer.config().listen.clone()),
+            Message::init(
+                peer.node_id(),
+                peer.config()
+                    .listen
+                    .clone()
+                    .try_into()
+                    .expect("within bound limits"),
+            ),
         );
     }
 


### PR DESCRIPTION
Support clearly defining message constraints by introducing a new vector type.  The vector type takes a statically defined upper bound as a Type parameter.

Should we pursue using this?  The code is to express the idea and not meant as a final version, some clean up will be in order.

```
pub struct InventoryAnnouncement {
    /// Node inventory.
    pub inventory: BoundedVec<INVENTORY_LIMIT, Id>,
    /// Time of announcement.
    pub timestamp: Timestamp,
}
```