### PR TITLE
Update ed25519-compact dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-compact"
-version = "1.0.16"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18997d4604542d0736fae2c5ad6de987f0a50530cbcc14a7ce5a685328a252d"
+checksum = "1f2d21333b679bbbac680b3eb45c86937e42f69277028f4e97b599b80b86c253"
 dependencies = [
  "ct-codecs",
  "getrandom 0.2.8",

--- a/radicle-cob/Cargo.toml
+++ b/radicle-cob/Cargo.toml
@@ -37,7 +37,7 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-ed25519-compact = { version = "1.0.12", features = ["pem"] }
+ed25519-compact = { version = "2.0.2", features = ["pem"] }
 fastrand = { version = "1.8.0", default-features = false }
 git-ref-format = { version = "0.1", features = ["macro"] }
 tempfile = { version = "3" }

--- a/radicle-crypto/Cargo.toml
+++ b/radicle-crypto/Cargo.toml
@@ -13,7 +13,7 @@ test = ["fastrand", "quickcheck"]
 ssh = ["base64", "radicle-ssh", "sha2", "ssh-key"]
 
 [dependencies]
-ed25519-compact = { version = "1.0.12", features = ["pem"] }
+ed25519-compact = { version = "2.0.2", features = ["pem"] }
 multibase = { version = "0.9.1" }
 serde = { version = "1", features = ["derive"] }
 sqlite = { version = "0.28.1", optional = true }

--- a/radicle/Cargo.toml
+++ b/radicle/Cargo.toml
@@ -15,7 +15,7 @@ automerge = { version = "0.1" }
 base64 = { version= "0.13" }
 byteorder = { version = "1.4" }
 crossbeam-channel = { version = "0.5.6" }
-ed25519-compact = { version = "1.0.12", features = ["pem"] }
+ed25519-compact = { version = "2.0.2", features = ["pem"] }
 fastrand = { version = "1.8.0" }
 git-ref-format = { version = "0", features = ["serde", "macro"] }
 multibase = { version = "0.9.1" }


### PR DESCRIPTION
v2.0 of `ed25519-compact` supports conversion between key types used in X25519 and Ed25519, where X25519 is required for a successful noise handshake