### PR TITLE
Get around circular-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,6 @@ dependencies = [
  "radicle-cob",
  "radicle-crypto",
  "radicle-git-ext",
- "radicle-node",
  "radicle-ssh",
  "serde",
  "serde_json",

--- a/radicle/Cargo.toml
+++ b/radicle/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [features]
 default = []
-test = ["quickcheck", "radicle-crypto/test", "radicle-node/test"]
+test = ["quickcheck", "radicle-crypto/test"]
 sql = ["sqlite"]
 
 [dependencies]
@@ -65,10 +65,5 @@ quickcheck = { version = "1", default-features = false }
 
 [dev-dependencies.radicle-crypto]
 path = "../radicle-crypto"
-version = "0"
-features = ["test"]
-
-[dev-dependencies.radicle-node]
-path = "../radicle-node"
 version = "0"
 features = ["test"]

--- a/radicle/src/node.rs
+++ b/radicle/src/node.rs
@@ -131,38 +131,3 @@ impl Handle for Node {
 pub fn connect<P: AsRef<Path>>(path: P) -> Result<Node, Error> {
     Node::connect(path)
 }
-
-#[cfg(test)]
-mod tests {
-    use std::thread;
-
-    use super::*;
-    use crate::test;
-
-    #[test]
-    fn test_track_untrack() {
-        let tmp = tempfile::tempdir().unwrap();
-        let socket = tmp.path().join("node.sock");
-        let proj = test::arbitrary::gen::<Id>(1);
-
-        thread::spawn({
-            use radicle_node as node;
-
-            let socket = socket.clone();
-            let handle = node::test::handle::Handle::default();
-
-            move || node::control::listen(socket, handle)
-        });
-
-        let handle = loop {
-            if let Ok(conn) = Node::connect(&socket) {
-                break conn;
-            }
-        };
-
-        assert!(handle.track(&proj).unwrap());
-        assert!(!handle.track(&proj).unwrap());
-        assert!(handle.untrack(&proj).unwrap());
-        assert!(!handle.untrack(&proj).unwrap());
-    }
-}


### PR DESCRIPTION
This was causing an issue in rust-analyzer, and probably would fail in other ways via cargo. In any case it wasn't a good idea.

Signed-off-by: Alexis Sellier <alexis@radicle.xyz>