### PR TITLE
node: Fix addresses sent to peers on conn.

### DIFF
--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -1271,7 +1271,7 @@ mod gossip {
         };
 
         let mut msgs = vec![
-            Message::init(*signer.public_key(), config.listen.clone()),
+            Message::init(*signer.public_key(), config.external_addresses.clone()),
             Message::inventory(gossip::inventory(timestamp, inventory), signer),
             Message::subscribe(config.filter(), timestamp, Timestamp::MAX),
         ];


### PR DESCRIPTION
Send the node's configured external addresses instead of its listenning addresses.  External addresses are ones which the service is reachable from the outside world, the listening addresses can be the wrong context (local area network, or 0.0.0.0).

Signed-off-by: Slack Coder <slackcoder@server.ky>