### PR TITLE
rad-issue: Change `reaction` flag to `emoji`

### DIFF
--- a/radicle-cli/src/commands/issue.rs
+++ b/radicle-cli/src/commands/issue.rs
@@ -123,7 +123,7 @@ impl Args for Options {
                         reason: CloseReason::Solved,
                     });
                 }
-                Long("reaction") if op == Some(OperationName::React) => {
+                Long("emoji") if op == Some(OperationName::React) => {
                     if let Some(emoji) = parser.value()?.to_str() {
                         reaction =
                             Some(Reaction::from_str(emoji).map_err(|_| anyhow!("invalid emoji"))?);


### PR DESCRIPTION
This is poor UX imo and I'd prefer it if we show the emojis in terminal somehow (like a TUI). Still the flag needs to be renamed to match the `help`.