### PR TITLE
Replace `quickcheck` with `qcheck`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,16 +768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,21 +2121,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "1.0.3"
+name = "qcheck"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+checksum = "b439bd4242da51d62d18c95e6a6add749346756b0d1a587dfd0cc22fa6b5f3f0"
 dependencies = [
- "env_logger",
- "log",
  "rand 0.8.5",
 ]
 
 [[package]]
-name = "quickcheck_macros"
+name = "qcheck-macros"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+checksum = "2742b9af5a690615904b18f11983f4db9ea7ad1c7e6ed3fb4b2402cdaaf5b1b5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2180,8 +2168,8 @@ dependencies = [
  "olpc-cjson",
  "once_cell",
  "pretty_assertions",
- "quickcheck",
- "quickcheck_macros",
+ "qcheck",
+ "qcheck-macros",
  "radicle-cob",
  "radicle-crdt",
  "radicle-crypto",
@@ -2233,8 +2221,8 @@ dependencies = [
  "git2",
  "log",
  "petgraph",
- "quickcheck",
- "quickcheck_macros",
+ "qcheck",
+ "qcheck-macros",
  "radicle-crypto",
  "radicle-git-ext",
  "serde",
@@ -2249,8 +2237,8 @@ version = "0.1.0"
 dependencies = [
  "fastrand",
  "num-traits",
- "quickcheck",
- "quickcheck_macros",
+ "qcheck",
+ "qcheck-macros",
  "radicle-crypto",
  "serde",
  "tempfile",
@@ -2266,8 +2254,8 @@ dependencies = [
  "fastrand",
  "git-ref-format 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase",
- "quickcheck",
- "quickcheck_macros",
+ "qcheck",
+ "qcheck-macros",
  "radicle-ssh",
  "serde",
  "sha2 0.10.6",
@@ -2335,8 +2323,8 @@ dependencies = [
  "nakamoto-net",
  "nakamoto-net-poll",
  "nonempty 0.8.0",
- "quickcheck",
- "quickcheck_macros",
+ "qcheck",
+ "qcheck-macros",
  "radicle",
  "radicle-crypto",
  "scrypt",

--- a/radicle-cob/Cargo.toml
+++ b/radicle-cob/Cargo.toml
@@ -41,8 +41,8 @@ ed25519-compact = { version = "2.0.2", features = ["pem"] }
 fastrand = { version = "1.8.0", default-features = false }
 git-ref-format = { version = "0.1", features = ["macro"] }
 tempfile = { version = "3" }
-quickcheck = { version = "1", default-features = false }
-quickcheck_macros = { version = "1", default-features = false }
+qcheck = { version = "1", default-features = false }
+qcheck-macros = { version = "1", default-features = false }
 
 [dev-dependencies.radicle-crypto]
 path = "../radicle-crypto"

--- a/radicle-cob/src/lib.rs
+++ b/radicle-cob/src/lib.rs
@@ -72,10 +72,10 @@
 //! [RFC-0662]: https://github.com/radicle-dev/radicle-link/blob/master/docs/rfc/0662-collaborative-objects.adoc
 
 #[cfg(test)]
-extern crate quickcheck;
+extern crate qcheck;
 #[cfg(test)]
 #[macro_use(quickcheck)]
-extern crate quickcheck_macros;
+extern crate qcheck_macros;
 
 extern crate radicle_crypto as crypto;
 extern crate radicle_git_ext as git_ext;

--- a/radicle-cob/src/test/arbitrary.rs
+++ b/radicle-cob/src/test/arbitrary.rs
@@ -1,6 +1,6 @@
 use std::{iter, marker::PhantomData};
 
-use quickcheck::Arbitrary;
+use qcheck::Arbitrary;
 
 use crate::{ObjectId, TypeName};
 
@@ -11,7 +11,7 @@ pub struct Invalid<T> {
 }
 
 impl Arbitrary for TypeName {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+    fn arbitrary(g: &mut qcheck::Gen) -> Self {
         let rng = fastrand::Rng::with_seed(u64::arbitrary(g));
         let mut name: Vec<String> = Vec::new();
         for _ in 0..rng.usize(1..5) {
@@ -28,7 +28,7 @@ impl Arbitrary for TypeName {
 }
 
 impl Arbitrary for ObjectId {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+    fn arbitrary(g: &mut qcheck::Gen) -> Self {
         let rng = fastrand::Rng::with_seed(u64::arbitrary(g));
         let bytes = iter::repeat_with(|| rng.u8(..))
             .take(20)
@@ -38,7 +38,7 @@ impl Arbitrary for ObjectId {
 }
 
 impl Arbitrary for Invalid<ObjectId> {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+    fn arbitrary(g: &mut qcheck::Gen) -> Self {
         let rng = fastrand::Rng::with_seed(u64::arbitrary(g));
         let value = iter::repeat_with(|| rng.alphanumeric())
             .take(rng.usize(21..50))

--- a/radicle-cob/src/tests.rs
+++ b/radicle-cob/src/tests.rs
@@ -2,7 +2,7 @@ use std::ops::ControlFlow;
 
 use crypto::test::signer::MockSigner;
 use git_ref_format::{refname, Component, RefString};
-use quickcheck::Arbitrary;
+use qcheck::Arbitrary;
 use radicle_crypto::Signer;
 
 use crate::{
@@ -280,7 +280,7 @@ fn invalid_parse_refstr(oid: Invalid<ObjectId>, typename: TypeName) {
 }
 
 fn gen<T: Arbitrary>(size: usize) -> T {
-    let mut gen = quickcheck::Gen::new(size);
+    let mut gen = qcheck::Gen::new(size);
 
     T::arbitrary(&mut gen)
 }

--- a/radicle-crdt/Cargo.toml
+++ b/radicle-crdt/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-test = ["fastrand", "quickcheck"]
+test = ["fastrand", "qcheck"]
 
 [dependencies]
 fastrand = { version = "1.8.0", optional = true }
 num-traits = { version = "0.2.15", default-features = false, features = ["std"] }
-quickcheck = { version = "1", optional = true }
+qcheck = { version = "1", optional = true }
 serde = { version = "1" }
 
 [dependencies.radicle-crypto]
@@ -19,7 +19,7 @@ features = []
 
 [dev-dependencies]
 fastrand = { version = "1.8.0" }
-quickcheck = { version = "1" }
-quickcheck_macros = { version = "1" }
+qcheck = { version = "1" }
+qcheck-macros = { version = "1" }
 radicle-crypto = { path = "../radicle-crypto", features = ["test"] }
 tempfile = { version = "3" }

--- a/radicle-crdt/src/gmap.rs
+++ b/radicle-crdt/src/gmap.rs
@@ -88,7 +88,7 @@ impl<K, V> Deref for GMap<K, V> {
 
 #[cfg(test)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     use super::*;
     use crate::ord::Max;

--- a/radicle-crdt/src/lib.rs
+++ b/radicle-crdt/src/lib.rs
@@ -116,7 +116,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{test, Max, Min, Semilattice};
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     #[quickcheck]
     fn prop_option_laws(a: Max<u8>, b: Max<u8>, c: Max<u8>) {

--- a/radicle-crdt/src/lwwmap.rs
+++ b/radicle-crdt/src/lwwmap.rs
@@ -96,7 +96,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     use super::*;
     use crate::ord::Max;

--- a/radicle-crdt/src/lwwreg.rs
+++ b/radicle-crdt/src/lwwreg.rs
@@ -76,7 +76,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     use super::*;
     use crate::Min;

--- a/radicle-crdt/src/lwwset.rs
+++ b/radicle-crdt/src/lwwset.rs
@@ -77,7 +77,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     #[quickcheck]
     fn prop_semilattice(

--- a/radicle-crdt/src/ord.rs
+++ b/radicle-crdt/src/ord.rs
@@ -115,14 +115,14 @@ impl<T: PartialOrd> Semilattice for Min<T> {
 mod arbitrary {
     use super::*;
 
-    impl<T: quickcheck::Arbitrary> quickcheck::Arbitrary for Max<T> {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+    impl<T: qcheck::Arbitrary> qcheck::Arbitrary for Max<T> {
+        fn arbitrary(g: &mut qcheck::Gen) -> Self {
             Self::from(T::arbitrary(g))
         }
     }
 
-    impl<T: quickcheck::Arbitrary> quickcheck::Arbitrary for Min<T> {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+    impl<T: qcheck::Arbitrary> qcheck::Arbitrary for Min<T> {
+        fn arbitrary(g: &mut qcheck::Gen) -> Self {
             Self::from(T::arbitrary(g))
         }
     }

--- a/radicle-crdt/src/redactable.rs
+++ b/radicle-crdt/src/redactable.rs
@@ -69,7 +69,7 @@ impl<T: PartialEq> Semilattice for Redactable<T> {
 
 #[cfg(test)]
 mod test {
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     use super::*;
     use crate::test;

--- a/radicle-crypto/Cargo.toml
+++ b/radicle-crypto/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 edition = "2021"
 
 [features]
-test = ["fastrand", "quickcheck"]
+test = ["fastrand", "qcheck"]
 ssh = ["base64", "radicle-ssh", "ssh-key"]
 
 [dependencies]
@@ -37,7 +37,7 @@ default-features = false
 features = ["std", "encryption", "rand_core", "getrandom"]
 optional = true
 
-[dependencies.quickcheck]
+[dependencies.qcheck]
 version = "1"
 default-features = false
 optional = true
@@ -54,6 +54,6 @@ optional = true
 
 [dev-dependencies]
 fastrand = { version = "1.8.0", default-features = false }
-quickcheck_macros = { version = "1", default-features = false }
-quickcheck = { version = "1", default-features = false }
+qcheck-macros = { version = "1", default-features = false }
+qcheck = { version = "1", default-features = false }
 tempfile = { version = "3.3.0" }

--- a/radicle-crypto/src/lib.rs
+++ b/radicle-crypto/src/lib.rs
@@ -395,7 +395,7 @@ pub mod keypair {
 #[cfg(test)]
 mod tests {
     use crate::PublicKey;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
     use std::str::FromStr;
 
     #[quickcheck]

--- a/radicle-crypto/src/ssh.rs
+++ b/radicle-crypto/src/ssh.rs
@@ -322,11 +322,10 @@ impl ExtendedSignature {
 mod test {
     use std::sync::{Arc, Mutex};
 
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     use super::{fmt, ExtendedSignature};
     use crate as crypto;
-    use crate::test::arbitrary::ByteArray;
     use crate::{PublicKey, SecretKey};
     use radicle_ssh::agent::client::{AgentClient, ClientStream, Error};
     use radicle_ssh::encoding::*;
@@ -352,9 +351,9 @@ mod test {
     }
 
     #[quickcheck]
-    fn prop_encode_decode_sk(input: ByteArray<64>) {
+    fn prop_encode_decode_sk(input: [u8; 64]) {
         let mut buf = Buffer::default();
-        let sk = crypto::SecretKey::from(input.into_inner());
+        let sk = crypto::SecretKey::from(input);
         sk.write(&mut buf);
 
         let mut cursor = buf.reader(0);

--- a/radicle-crypto/src/test/arbitrary.rs
+++ b/radicle-crypto/src/test/arbitrary.rs
@@ -1,11 +1,11 @@
-use quickcheck::Arbitrary;
+use qcheck::Arbitrary;
 
 use crate::{hash, test::signer::MockSigner, KeyPair, PublicKey, SecretKey, Seed};
 
 impl Arbitrary for MockSigner {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let bytes: ByteArray<32> = Arbitrary::arbitrary(g);
-        let seed = Seed::new(bytes.into_inner());
+    fn arbitrary(g: &mut qcheck::Gen) -> Self {
+        let bytes: [u8; 32] = Arbitrary::arbitrary(g);
+        let seed = Seed::new(bytes);
         let sk = KeyPair::from_seed(seed).sk;
 
         MockSigner::from(SecretKey::from(sk))
@@ -13,9 +13,9 @@ impl Arbitrary for MockSigner {
 }
 
 impl Arbitrary for PublicKey {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let bytes: ByteArray<32> = Arbitrary::arbitrary(g);
-        let seed = Seed::new(bytes.into_inner());
+    fn arbitrary(g: &mut qcheck::Gen) -> Self {
+        let bytes: [u8; 32] = Arbitrary::arbitrary(g);
+        let seed = Seed::new(bytes);
         let keypair = KeyPair::from_seed(seed);
 
         PublicKey(keypair.pk)
@@ -23,31 +23,8 @@ impl Arbitrary for PublicKey {
 }
 
 impl Arbitrary for hash::Digest {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+    fn arbitrary(g: &mut qcheck::Gen) -> Self {
         let bytes: Vec<u8> = Arbitrary::arbitrary(g);
         hash::Digest::new(&bytes)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ByteArray<const N: usize>([u8; N]);
-
-impl<const N: usize> ByteArray<N> {
-    pub fn into_inner(self) -> [u8; N] {
-        self.0
-    }
-
-    pub fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
-    }
-}
-
-impl<const N: usize> Arbitrary for ByteArray<N> {
-    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        let mut bytes: [u8; N] = [0; N];
-        for byte in &mut bytes {
-            *byte = u8::arbitrary(g);
-        }
-        Self(bytes)
     }
 }

--- a/radicle-node/Cargo.toml
+++ b/radicle-node/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alexis Sellier <alexis@radicle.xyz>"]
 edition = "2021"
 
 [features]
-test = ["radicle/test", "radicle-crypto/test", "quickcheck"]
+test = ["radicle/test", "radicle-crypto/test", "qcheck"]
 
 [dependencies]
 anyhow = { version = "1" }
@@ -22,7 +22,7 @@ log = { version = "0.4.17", features = ["std"] }
 nakamoto-net = { version = "0.3.0" }
 nakamoto-net-poll = { version = "0.3.0" }
 nonempty = { version = "0.8.0", features = ["serialize"] }
-quickcheck = { version = "1", default-features = false, optional = true }
+qcheck = { version = "1", default-features = false, optional = true }
 sqlite = { version = "0.28.1" }
 sqlite3-src = { version = "0.4.0", features = ["bundled"] } # Ensures static linking
 scrypt = { version = "0.10.0", default-features = false }
@@ -39,5 +39,5 @@ features = ["sql"]
 [dev-dependencies]
 radicle = { path = "../radicle", version = "*", features = ["test"] }
 radicle-crypto = { path = "../radicle-crypto", version = "*", features = ["test"] }
-quickcheck = { version = "1", default-features = false }
-quickcheck_macros = { version = "1", default-features = false }
+qcheck = { version = "1", default-features = false }
+qcheck-macros = { version = "1", default-features = false }

--- a/radicle-node/src/deserializer.rs
+++ b/radicle-node/src/deserializer.rs
@@ -76,7 +76,7 @@ impl<D: wire::Decode> Iterator for Deserializer<D> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     const MSG_HELLO: &[u8] = &[5, b'h', b'e', b'l', b'l', b'o'];
     const MSG_BYE: &[u8] = &[3, b'b', b'y', b'e'];

--- a/radicle-node/src/service/message.rs
+++ b/radicle-node/src/service/message.rs
@@ -508,7 +508,7 @@ mod tests {
 
     use crate::crypto::test::signer::MockSigner;
     use crate::test::arbitrary;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     #[test]
     fn test_inventory_limit() {

--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -973,7 +973,7 @@ fn prop_inventory_exchange_dense() {
             }
         }
     }
-    quickcheck::QuickCheck::new()
-        .gen(quickcheck::Gen::new(8))
+    qcheck::QuickCheck::new()
+        .gen(qcheck::Gen::new(8))
         .quickcheck(property as fn(MockStorage, MockStorage, MockStorage));
 }

--- a/radicle-node/src/wire.rs
+++ b/radicle-node/src/wire.rs
@@ -628,11 +628,11 @@ impl<R, S, W, G, H: Handshake> Iterator for Wire<R, S, W, G, H> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     use crate::crypto::Unverified;
     use crate::storage::refs::SignedRefs;
-    use crate::test::{arbitrary, assert_matches};
+    use crate::test::assert_matches;
 
     #[quickcheck]
     fn prop_u8(input: u8) {
@@ -655,13 +655,13 @@ mod tests {
     }
 
     #[quickcheck]
-    fn prop_string(input: String) -> quickcheck::TestResult {
+    fn prop_string(input: String) -> qcheck::TestResult {
         if input.len() > u8::MAX as usize {
-            return quickcheck::TestResult::discard();
+            return qcheck::TestResult::discard();
         }
         assert_eq!(deserialize::<String>(&serialize(&input)).unwrap(), input);
 
-        quickcheck::TestResult::passed()
+        qcheck::TestResult::passed()
     }
 
     #[quickcheck]
@@ -701,8 +701,8 @@ mod tests {
     }
 
     #[quickcheck]
-    fn prop_signature(input: arbitrary::ByteArray<64>) {
-        let signature = Signature::from(input.into_inner());
+    fn prop_signature(input: [u8; 64]) {
+        let signature = Signature::from(input);
 
         assert_eq!(
             deserialize::<Signature>(&serialize(&signature)).unwrap(),
@@ -711,8 +711,8 @@ mod tests {
     }
 
     #[quickcheck]
-    fn prop_oid(input: arbitrary::ByteArray<20>) {
-        let oid = git::Oid::try_from(input.into_inner().as_slice()).unwrap();
+    fn prop_oid(input: [u8; 20]) {
+        let oid = git::Oid::try_from(input.as_slice()).unwrap();
 
         assert_eq!(deserialize::<git::Oid>(&serialize(&oid)).unwrap(), oid);
     }

--- a/radicle-node/src/wire/message.rs
+++ b/radicle-node/src/wire/message.rs
@@ -359,7 +359,7 @@ impl wire::Decode for ZeroBytes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     use crate::deserializer::Deserializer;
     use crate::wire::{self, Encode};
@@ -423,8 +423,8 @@ mod tests {
             }
         }
 
-        quickcheck::QuickCheck::new()
-            .gen(quickcheck::Gen::new(16))
+        qcheck::QuickCheck::new()
+            .gen(qcheck::Gen::new(16))
             .quickcheck(property as fn(items: Vec<Message>));
     }
 

--- a/radicle/Cargo.toml
+++ b/radicle/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [features]
 default = []
-test = ["quickcheck", "radicle-crypto/test"]
+test = ["qcheck", "radicle-crypto/test"]
 sql = ["sqlite"]
 
 [dependencies]
@@ -56,15 +56,15 @@ path = "../radicle-ssh"
 version = "0"
 default-features = false
 
-[dependencies.quickcheck]
+[dependencies.qcheck]
 version = "1"
 default-features = false
 optional = true
 
 [dev-dependencies]
 pretty_assertions = { version = "1.3.0" }
-quickcheck_macros = { version = "1", default-features = false }
-quickcheck = { version = "1", default-features = false }
+qcheck-macros = { version = "1", default-features = false }
+qcheck = { version = "1", default-features = false }
 
 [dev-dependencies.radicle-crypto]
 path = "../radicle-crypto"

--- a/radicle/src/cob/patch.rs
+++ b/radicle/src/cob/patch.rs
@@ -778,7 +778,7 @@ mod test {
     use radicle_crdt::test::{assert_laws, WeightedGenerator};
 
     use pretty_assertions::assert_eq;
-    use quickcheck::{Arbitrary, TestResult};
+    use qcheck::{Arbitrary, TestResult};
 
     use super::*;
     use crate::cob::op::{Actor, ActorId};
@@ -804,7 +804,7 @@ mod test {
     }
 
     impl<const N: usize> Arbitrary for Changes<N> {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        fn arbitrary(g: &mut qcheck::Gen) -> Self {
             type State = (clock::Lamport, Vec<OpId>, Vec<Tag>);
 
             let author = ActorId::from([0; 32]);
@@ -927,9 +927,9 @@ mod test {
             TestResult::passed()
         }
 
-        quickcheck::QuickCheck::new()
+        qcheck::QuickCheck::new()
             .min_tests_passed(100)
-            .gen(quickcheck::Gen::new(8))
+            .gen(qcheck::Gen::new(8))
             .quickcheck(property as fn(Changes<3>) -> TestResult);
     }
 

--- a/radicle/src/cob/thread.rs
+++ b/radicle/src/cob/thread.rs
@@ -290,8 +290,8 @@ mod tests {
 
     use crate::crypto::test::signer::MockSigner;
     use pretty_assertions::assert_eq;
-    use quickcheck::Arbitrary;
-    use quickcheck_macros::quickcheck;
+    use qcheck::Arbitrary;
+    use qcheck_macros::quickcheck;
 
     use super::*;
     use crate as radicle;
@@ -316,7 +316,7 @@ mod tests {
     }
 
     impl<const N: usize> Arbitrary for Changes<N> {
-        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        fn arbitrary(g: &mut qcheck::Gen) -> Self {
             let author = ActorId::from([0; 32]);
             let rng = fastrand::Rng::with_seed(u64::arbitrary(g));
             let gen =

--- a/radicle/src/identity.rs
+++ b/radicle/src/identity.rs
@@ -83,7 +83,7 @@ impl Deref for Did {
 mod test {
     use super::*;
     use crate::crypto::PublicKey;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
     use std::collections::HashSet;
 
     #[quickcheck]

--- a/radicle/src/identity/project.rs
+++ b/radicle/src/identity/project.rs
@@ -504,7 +504,7 @@ mod test {
     use crate::test::fixtures;
 
     use super::*;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     #[test]
     fn test_not_found() {

--- a/radicle/src/storage/refs.rs
+++ b/radicle/src/storage/refs.rs
@@ -367,7 +367,7 @@ pub mod canonical {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck_macros::quickcheck;
+    use qcheck_macros::quickcheck;
 
     #[quickcheck]
     fn prop_canonical_roundtrip(refs: Refs) {


### PR DESCRIPTION
The latter is a fork of the former, which adds const generics and a bunch of other quality of life and performance improvements that aren't in the original crate due to it being unmaintained.

I'm maintaing the fork here: https://github.com/cloudhead/qcheck

Signed-off-by: Alexis Sellier <alexis@radicle.xyz>