### PR TITLE
node: Limit number of Refs in RefAnnouncements

### DIFF
--- a/radicle-node/src/bounded.rs
+++ b/radicle-node/src/bounded.rs
@@ -18,6 +18,25 @@ impl<T, const N: usize> BoundedVec<T, N> {
         BoundedVec { v: Vec::new() }
     }
 
+    /// Build a `BoundedVec` by consuming from the given iterator up to its limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use radicle_node::bounded;
+    ///
+    /// let mut iter = (0..4).into_iter();
+    /// let bounded: bounded::BoundedVec<i32,3> = bounded::BoundedVec::collect_from(&mut iter);
+    ///
+    /// assert_eq!(bounded.len(), 3);
+    /// assert_eq!(iter.count(), 1);
+    /// ```
+    pub fn collect_from<I: Iterator<Item = T>>(iter: &mut I) -> Self {
+        BoundedVec {
+            v: iter.into_iter().take(N).collect(),
+        }
+    }
+
     /// Create a new `BoundedVec<T,N>` which takes upto the first N values of its argument, taking
     /// ownership.
     ///

--- a/radicle-node/src/test/arbitrary.rs
+++ b/radicle-node/src/test/arbitrary.rs
@@ -56,7 +56,9 @@ impl Arbitrary for Message {
                 node: NodeId::arbitrary(g),
                 message: RefsAnnouncement {
                     id: Id::arbitrary(g),
-                    refs: Refs::arbitrary(g),
+                    refs: BoundedVec::collect_from(
+                        &mut Refs::arbitrary(g).iter().map(|(k, v)| (k.clone(), *v)),
+                    ),
                     timestamp: Timestamp::arbitrary(g),
                 }
                 .into(),

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-use std::collections::BTreeMap;
 use std::iter;
 use std::net;
 use std::ops::{Deref, DerefMut};
@@ -13,7 +12,7 @@ use crate::crypto::test::signer::MockSigner;
 use crate::crypto::Signer;
 use crate::identity::Id;
 use crate::node;
-use crate::prelude::NodeId;
+use crate::prelude::*;
 use crate::service;
 use crate::service::message::*;
 use crate::service::reactor::Io;
@@ -214,7 +213,7 @@ where
     }
 
     pub fn refs_announcement(&self, id: Id) -> Message {
-        let refs = BTreeMap::new().into();
+        let refs = BoundedVec::new();
         let ann = AnnouncementMessage::from(RefsAnnouncement {
             id,
             refs,

--- a/radicle-node/src/wire/message.rs
+++ b/radicle-node/src/wire/message.rs
@@ -130,7 +130,7 @@ impl wire::Encode for RefsAnnouncement {
 impl wire::Decode for RefsAnnouncement {
     fn decode<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<Self, wire::Error> {
         let id = Id::decode(reader)?;
-        let refs = Refs::decode(reader)?;
+        let refs = BoundedVec::decode(reader)?;
         let timestamp = Timestamp::decode(reader)?;
 
         Ok(Self {

--- a/radicle/src/test/arbitrary.rs
+++ b/radicle/src/test/arbitrary.rs
@@ -15,6 +15,23 @@ use crate::storage;
 use crate::storage::refs::{Refs, SignedRefs};
 use crate::test::storage::MockStorage;
 
+pub fn oid() -> storage::Oid {
+    let oid_bytes: [u8; 20] = gen(1);
+    storage::Oid::try_from(oid_bytes.as_slice()).unwrap()
+}
+
+pub fn refstring(len: usize) -> git::RefString {
+    let mut buf = Vec::<u8>::new();
+    for _ in 0..len {
+        buf.push(fastrand::u8(0x61..0x7a));
+    }
+    std::str::from_utf8(&buf)
+        .unwrap()
+        .to_string()
+        .try_into()
+        .unwrap()
+}
+
 pub fn set<T: Eq + Hash + Arbitrary>(range: impl RangeBounds<usize>) -> HashSet<T> {
     let size = fastrand::usize(range);
     let mut set = HashSet::with_capacity(size);


### PR DESCRIPTION
Use the BoundedVec to limit the supported number of refs in RefAnnouncement messages.  The size (236) is the maximum supported by message wire size.

To reduce the complexity of the changes, BoundedVec is used again instead of using a new bounded Refs or BTreeMap.  This requires defining new Decode/Encode logic for Ref's element types, and workarounds for arbitrary instances.

Signed-off-by: Slack Coder <slackcoder@server.ky>

closes #16