### PR TITLE
Remove delegate names from identity doc

### DIFF
--- a/radicle-cli/examples/rad-init.md
+++ b/radicle-cli/examples/rad-init.md
@@ -3,19 +3,19 @@ To create your first radicle project, navigate to a git repository, and run
 the `init` command:
 
 ```
-$ rad init --name acme --description "Acme's repository" --no-confirm
+$ rad init --name heartwood --description "Radicle Heartwood Protocol & Stack" --no-confirm
 
 Initializing local 🌱 project in .
 
-ok Project acme created
+ok Project heartwood created
 {
-  "name": "acme",
-  "description": "Acme's repository",
+  "name": "heartwood",
+  "description": "Radicle Heartwood Protocol & Stack",
   "default-branch": "master"
 }
 
 
-Your project id is rad:z4EXAgDJk11uFThfVir5FivKhiAeK. You can show it any time by running:
+Your project id is rad:zb2rNRYmmz7SLZ7xMjM7dddswC3K. You can show it any time by running:
    rad .
 
 To publish your project to the network, run:
@@ -27,5 +27,5 @@ Projects can be listed with the `ls` command:
 
 ```
 $ rad ls
-acme rad:z4EXAgDJk11uFThfVir5FivKhiAeK cdf76ce Acme's repository
+heartwood rad:zb2rNRYmmz7SLZ7xMjM7dddswC3K cdf76ce Radicle Heartwood Protocol & Stack
 ```

--- a/radicle-cli/src/commands/checkout.rs
+++ b/radicle-cli/src/commands/checkout.rs
@@ -110,8 +110,8 @@ pub fn execute(options: Options, profile: &Profile) -> anyhow::Result<PathBuf> {
     spinner.finish();
 
     let remotes = delegates
-        .iter()
-        .map(|d| *d.id)
+        .into_iter()
+        .map(|did| *did)
         .filter(|id| id != profile.id())
         .collect::<Vec<_>>();
 

--- a/radicle-cli/src/commands/clone.rs
+++ b/radicle-cli/src/commands/clone.rs
@@ -101,7 +101,7 @@ pub fn clone(id: Id, _interactive: Interactive, ctx: impl term::Context) -> anyh
     let delegates = doc
         .delegates
         .iter()
-        .map(|d| *d.id)
+        .map(|d| **d)
         .filter(|id| id != profile.id())
         .collect::<Vec<_>>();
     let default_branch = doc.payload.default_branch.clone();

--- a/radicle-crypto/src/test/signer.rs
+++ b/radicle-crypto/src/test/signer.rs
@@ -8,12 +8,16 @@ pub struct MockSigner {
 
 impl MockSigner {
     pub fn new(rng: &mut fastrand::Rng) -> Self {
-        let mut bytes: [u8; 32] = [0; 32];
+        let mut seed: [u8; 32] = [0; 32];
 
-        for byte in &mut bytes {
+        for byte in &mut seed {
             *byte = rng.u8(..);
         }
-        let seed = Seed::new(bytes);
+        Self::from_seed(seed)
+    }
+
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        let seed = Seed::new(seed);
         let keypair = KeyPair::from_seed(seed);
 
         Self::from(SecretKey::from(keypair.sk))

--- a/radicle-httpd/src/api/v1/delegates.rs
+++ b/radicle-httpd/src/api/v1/delegates.rs
@@ -40,7 +40,7 @@ async fn delegates_projects_handler(
             let Ok((_, head)) = repo.head() else { return None };
             let Ok(Doc { payload, delegates, .. }) = repo.project_of(ctx.profile.id()) else { return None };
 
-            if !delegates.iter().any(|d| d.id == delegate) {
+            if !delegates.iter().any(|d| *d == delegate) {
                 return None;
             }
 

--- a/radicle/src/identity.rs
+++ b/radicle/src/identity.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::crypto;
 
 pub use crypto::PublicKey;
-pub use project::{Delegate, Doc, Id, IdError};
+pub use project::{Doc, Id, IdError};
 
 #[derive(Error, Debug)]
 pub enum DidError {

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -59,11 +59,7 @@ pub fn init<G: Signer>(
 ) -> Result<(Id, identity::Doc<Verified>, SignedRefs<Verified>), InitError> {
     // TODO: Better error when project id already exists in storage, but remote doesn't.
     let pk = signer.public_key();
-    let delegate = identity::Delegate {
-        // TODO: Use actual user name.
-        name: String::from("anonymous"),
-        id: identity::Did::from(*pk),
-    };
+    let delegate = identity::Did::from(*pk);
     let doc = identity::Doc::initial(
         name.to_owned(),
         description.to_owned(),
@@ -348,7 +344,7 @@ mod tests {
     use radicle_crypto::test::signer::MockSigner;
 
     use crate::git::{name::component, qualified, Qualified};
-    use crate::identity::{Delegate, Did};
+    use crate::identity::Did;
     use crate::storage::git::transport;
     use crate::storage::git::Storage;
     use crate::storage::{ReadStorage, WriteStorage};
@@ -403,13 +399,7 @@ mod tests {
         assert_eq!(project.name, "acme");
         assert_eq!(project.description, "Acme's repo");
         assert_eq!(project.default_branch, git::refname!("master"));
-        assert_eq!(
-            project.delegates.first(),
-            &Delegate {
-                name: String::from("anonymous"),
-                id: Did::from(public_key),
-            }
-        );
+        assert_eq!(project.delegates.first(), &Did::from(public_key));
     }
 
     #[test]

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -500,7 +500,7 @@ impl ReadRepository for Repository {
 
         let mut heads = Vec::new();
         for delegate in project.delegates.iter() {
-            let r = self.reference_oid(&delegate.id, &branch_ref)?.into();
+            let r = self.reference_oid(delegate, &branch_ref)?.into();
 
             heads.push(r);
         }


### PR DESCRIPTION
We are working on other mechanisms to help identify keys, and this is just redundant.

Also update some of the CLI examples to create a canonical example for documentation.

Signed-off-by: Alexis Sellier <alexis@radicle.xyz>