### PR TITLE
Tracking of peers via the CLI, and aliases

### DIFF
--- a/radicle-cli/src/commands/clone.rs
+++ b/radicle-cli/src/commands/clone.rs
@@ -84,7 +84,7 @@ pub fn clone(id: Id, _interactive: Interactive, ctx: impl term::Context) -> anyh
     let signer = term::signer(&profile)?;
 
     // Track & fetch project.
-    node.track(&id).context("track")?;
+    node.track_repo(&id).context("track")?;
     node.fetch(&id).context("fetch")?;
 
     // Create a local fork of the project, under our own id.

--- a/radicle-cli/src/commands/clone.rs
+++ b/radicle-cli/src/commands/clone.rs
@@ -80,12 +80,12 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
 
 pub fn clone(id: Id, _interactive: Interactive, ctx: impl term::Context) -> anyhow::Result<()> {
     let profile = ctx.profile()?;
-    let node = radicle::node::connect(profile.node())?;
+    let mut node = radicle::node::connect(profile.node())?;
     let signer = term::signer(&profile)?;
 
     // Track & fetch project.
-    node.track_repo(&id).context("track")?;
-    node.fetch(&id).context("fetch")?;
+    node.track_repo(id).context("track")?;
+    node.fetch(id).context("fetch")?;
 
     // Create a local fork of the project, under our own id.
     rad::fork(id, &signer, &profile.storage).context("fork")?;

--- a/radicle-cli/src/commands/track.rs
+++ b/radicle-cli/src/commands/track.rs
@@ -1,8 +1,8 @@
 use std::ffi::OsString;
+use std::str::FromStr;
 
 use anyhow::{anyhow, Context as _};
 
-use radicle::identity::project::Id;
 use radicle::node::Handle;
 use radicle::prelude::*;
 use radicle::storage::WriteStorage;
@@ -12,15 +12,16 @@ use crate::terminal::args::{Args, Error, Help};
 
 pub const HELP: Help = Help {
     name: "track",
-    description: "Manage project tracking relationships",
+    description: "Manage project tracking policy",
     version: env!("CARGO_PKG_VERSION"),
     usage: r#"
 Usage
 
-    rad track [<id>] [--fetch]
+    rad track <peer> [--fetch] [--alias <name>]
 
 Options
 
+    --alias <name>         Add an alias to this peer identifier
     --fetch                Fetch the peer's refs into the working copy
     --verbose, -v          Verbose output
     --help                 Print help
@@ -29,7 +30,8 @@ Options
 
 #[derive(Debug)]
 pub struct Options {
-    pub id: Option<Id>,
+    pub peer: NodeId,
+    pub alias: Option<String>,
     pub fetch: bool,
     pub verbose: bool,
 }
@@ -39,21 +41,31 @@ impl Args for Options {
         use lexopt::prelude::*;
 
         let mut parser = lexopt::Parser::from_args(args);
-        let mut id: Option<Id> = None;
+        let mut peer: Option<NodeId> = None;
+        let mut alias: Option<String> = None;
         let mut fetch = true;
         let mut verbose = false;
 
         while let Some(arg) = parser.next()? {
             match arg {
+                Long("alias") => {
+                    let name = parser.value()?;
+                    let name = name
+                        .to_str()
+                        .to_owned()
+                        .ok_or_else(|| anyhow!("alias specified is not UTF-8"))?;
+
+                    alias = Some(name.to_owned());
+                }
                 Long("no-fetch") => fetch = false,
                 Long("verbose") | Short('v') => verbose = true,
-                Value(val) if id.is_none() => {
+                Value(val) if peer.is_none() => {
                     let val = val.to_string_lossy();
 
-                    if let Ok(val) = Id::from_human(&val) {
-                        id = Some(val);
+                    if let Ok(val) = NodeId::from_str(&val) {
+                        peer = Some(val);
                     } else {
-                        return Err(anyhow!("invalid ID '{}'", val));
+                        return Err(anyhow!("invalid Node ID '{}'", val));
                     }
                 }
                 Long("help") => {
@@ -65,18 +77,24 @@ impl Args for Options {
             }
         }
 
-        Ok((Options { id, fetch, verbose }, vec![]))
+        Ok((
+            Options {
+                peer: peer.ok_or_else(|| anyhow!("a peer to track must be supplied"))?,
+                alias,
+                fetch,
+                verbose,
+            },
+            vec![],
+        ))
     }
 }
 
 pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
-    let id = options
-        .id
-        .or_else(|| radicle::rad::cwd().ok().map(|(_, id)| id))
-        .context("current directory is not a git repository; please supply an `<id>`")?;
+    let peer = options.peer;
     let profile = ctx.profile()?;
     let storage = &profile.storage;
-    let Doc { payload, .. } = storage.repository(id)?.project_of(profile.id())?;
+    let (_, rid) = radicle::rad::cwd().context("this command must be run within a project")?;
+    let Doc { payload, .. } = storage.repository(rid)?.project_of(profile.id())?;
     let node = radicle::node::connect(&profile.node())?;
 
     term::info!(
@@ -85,16 +103,22 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     );
     term::blank();
 
-    let tracked = node.track(&id)?;
-    term::success!(
-        "Tracking relationship for {} ({}) {}",
-        term::format::tertiary(&payload.name),
-        &id.to_human(),
-        if tracked { "established" } else { "exists" }
-    );
+    let tracked = node.track_node(&peer, options.alias.as_deref())?;
+    let outcome = if tracked { "established" } else { "exists" };
+
+    if let Some(alias) = options.alias {
+        term::success!(
+            "Tracking relationship with {} ({}) {}",
+            term::format::tertiary(alias),
+            peer,
+            outcome
+        );
+    } else {
+        term::success!("Tracking relationship with {} {}", peer, outcome);
+    }
 
     if options.fetch {
-        node.fetch(&id)?;
+        node.fetch(&rid)?;
     }
 
     Ok(())

--- a/radicle-cli/src/commands/track.rs
+++ b/radicle-cli/src/commands/track.rs
@@ -95,7 +95,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let storage = &profile.storage;
     let (_, rid) = radicle::rad::cwd().context("this command must be run within a project")?;
     let Doc { payload, .. } = storage.repository(rid)?.project_of(profile.id())?;
-    let node = radicle::node::connect(&profile.node())?;
+    let mut node = radicle::node::connect(&profile.node())?;
 
     term::info!(
         "Establishing 🌱 tracking relationship for {}",
@@ -103,7 +103,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     );
     term::blank();
 
-    let tracked = node.track_node(&peer, options.alias.as_deref())?;
+    let tracked = node.track_node(peer, options.alias.clone())?;
     let outcome = if tracked { "established" } else { "exists" };
 
     if let Some(alias) = options.alias {
@@ -118,7 +118,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     }
 
     if options.fetch {
-        node.fetch(&rid)?;
+        node.fetch(rid)?;
     }
 
     Ok(())

--- a/radicle-cli/src/commands/untrack.rs
+++ b/radicle-cli/src/commands/untrack.rs
@@ -89,5 +89,5 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
 
 pub fn untrack(id: Id, profile: &Profile) -> anyhow::Result<bool> {
     let node = radicle::node::connect(profile.node())?;
-    node.untrack(&id).map_err(|e| anyhow!(e))
+    node.untrack_repo(&id).map_err(|e| anyhow!(e))
 }

--- a/radicle-cli/src/commands/untrack.rs
+++ b/radicle-cli/src/commands/untrack.rs
@@ -88,6 +88,6 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
 }
 
 pub fn untrack(id: Id, profile: &Profile) -> anyhow::Result<bool> {
-    let node = radicle::node::connect(profile.node())?;
-    node.untrack_repo(&id).map_err(|e| anyhow!(e))
+    let mut node = radicle::node::connect(profile.node())?;
+    node.untrack_repo(id).map_err(|e| anyhow!(e))
 }

--- a/radicle-node/src/client/handle.rs
+++ b/radicle-node/src/client/handle.rs
@@ -55,12 +55,25 @@ pub struct Handle<W: Waker> {
     pub(crate) waker: W,
 }
 
-impl<W: Waker> traits::Handle for Handle<W> {
+impl<W: Waker> Handle<W> {
+    fn command(&self, cmd: service::Command) -> Result<(), Error> {
+        self.commands.send(cmd)?;
+        self.waker.wake()?;
+
+        Ok(())
+    }
+}
+
+impl<W: Waker> radicle::node::Handle for Handle<W> {
+    type Session = Session;
+    type FetchLookup = FetchLookup;
+    type Error = Error;
+
     fn listening(&self) -> Result<net::SocketAddr, Error> {
         self.listening.recv().map_err(Error::from)
     }
 
-    fn fetch(&mut self, id: Id) -> Result<FetchLookup, Error> {
+    fn fetch(&mut self, id: Id) -> Result<Self::FetchLookup, Error> {
         let (sender, receiver) = chan::bounded(1);
         self.commands.send(service::Command::Fetch(id, sender))?;
         receiver.recv().map_err(Error::from)
@@ -96,13 +109,6 @@ impl<W: Waker> traits::Handle for Handle<W> {
 
     fn announce_refs(&mut self, id: Id) -> Result<(), Error> {
         self.command(service::Command::AnnounceRefs(id))
-    }
-
-    fn command(&self, cmd: service::Command) -> Result<(), Error> {
-        self.commands.send(cmd)?;
-        self.waker.wake()?;
-
-        Ok(())
     }
 
     fn routing(&self) -> Result<chan::Receiver<(Id, NodeId)>, Error> {
@@ -149,37 +155,5 @@ impl<W: Waker> traits::Handle for Handle<W> {
         self.waker.wake()?;
 
         Ok(())
-    }
-}
-
-pub mod traits {
-    use super::*;
-
-    pub trait Handle {
-        /// Wait for the node's listening socket to be bound.
-        fn listening(&self) -> Result<net::SocketAddr, Error>;
-        /// Retrieve or update the project from network.
-        fn fetch(&mut self, id: Id) -> Result<FetchLookup, Error>;
-        /// Start tracking the given project. Doesn't do anything if the project is already
-        /// tracked.
-        fn track_repo(&mut self, id: Id) -> Result<bool, Error>;
-        /// Start tracking the given node.
-        fn track_node(&mut self, id: NodeId, alias: Option<String>) -> Result<bool, Error>;
-        /// Untrack the given project and delete it from storage.
-        fn untrack_repo(&mut self, id: Id) -> Result<bool, Error>;
-        /// Untrack the given node.
-        fn untrack_node(&mut self, id: NodeId) -> Result<bool, Error>;
-        /// Notify the client that a project has been updated.
-        fn announce_refs(&mut self, id: Id) -> Result<(), Error>;
-        /// Send a command to the command channel, and wake up the event loop.
-        fn command(&self, cmd: service::Command) -> Result<(), Error>;
-        /// Ask the client to shutdown.
-        fn shutdown(self) -> Result<(), Error>;
-        /// Query the routing table entries.
-        fn routing(&self) -> Result<chan::Receiver<(Id, NodeId)>, Error>;
-        /// Query the peer session state.
-        fn sessions(&self) -> Result<chan::Receiver<(NodeId, Session)>, Error>;
-        /// Query the inventory.
-        fn inventory(&self) -> Result<chan::Receiver<Id>, Error>;
     }
 }

--- a/radicle-node/src/test/handle.rs
+++ b/radicle-node/src/test/handle.rs
@@ -8,11 +8,13 @@ use crate::client::handle::Error;
 use crate::identity::Id;
 use crate::service;
 use crate::service::FetchLookup;
+use crate::service::NodeId;
 
 #[derive(Default, Clone)]
 pub struct Handle {
     pub updates: Arc<Mutex<Vec<Id>>>,
-    pub tracking: HashSet<Id>,
+    pub tracking_repos: HashSet<Id>,
+    pub tracking_nodes: HashSet<NodeId>,
 }
 
 impl traits::Handle for Handle {
@@ -24,12 +26,20 @@ impl traits::Handle for Handle {
         Ok(FetchLookup::NotFound)
     }
 
-    fn track(&mut self, id: Id) -> Result<bool, Error> {
-        Ok(self.tracking.insert(id))
+    fn track_repo(&mut self, id: Id) -> Result<bool, Error> {
+        Ok(self.tracking_repos.insert(id))
     }
 
-    fn untrack(&mut self, id: Id) -> Result<bool, Error> {
-        Ok(self.tracking.remove(&id))
+    fn untrack_repo(&mut self, id: Id) -> Result<bool, Error> {
+        Ok(self.tracking_repos.remove(&id))
+    }
+
+    fn track_node(&mut self, id: NodeId, _alias: Option<String>) -> Result<bool, Error> {
+        Ok(self.tracking_nodes.insert(id))
+    }
+
+    fn untrack_node(&mut self, id: NodeId) -> Result<bool, Error> {
+        Ok(self.tracking_nodes.remove(&id))
     }
 
     fn announce_refs(&mut self, id: Id) -> Result<(), Error> {

--- a/radicle-node/src/test/handle.rs
+++ b/radicle-node/src/test/handle.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 
 use crossbeam_channel as chan;
 
-use crate::client::handle::traits;
 use crate::client::handle::Error;
 use crate::identity::Id;
 use crate::service;
@@ -17,7 +16,11 @@ pub struct Handle {
     pub tracking_nodes: HashSet<NodeId>,
 }
 
-impl traits::Handle for Handle {
+impl radicle::node::Handle for Handle {
+    type Error = Error;
+    type Session = service::Session;
+    type FetchLookup = FetchLookup;
+
     fn listening(&self) -> Result<std::net::SocketAddr, Error> {
         unimplemented!()
     }
@@ -45,10 +48,6 @@ impl traits::Handle for Handle {
     fn announce_refs(&mut self, id: Id) -> Result<(), Error> {
         self.updates.lock().unwrap().push(id);
 
-        Ok(())
-    }
-
-    fn command(&self, _cmd: service::Command) -> Result<(), Error> {
         Ok(())
     }
 

--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -353,7 +353,7 @@ fn test_tracking() {
     let proj_id: identity::Id = test::arbitrary::gen(1);
 
     let (sender, receiver) = chan::bounded(1);
-    alice.command(Command::Track(proj_id, sender));
+    alice.command(Command::TrackRepo(proj_id, sender));
     let policy_change = receiver
         .recv()
         .map_err(client::handle::Error::from)
@@ -362,7 +362,7 @@ fn test_tracking() {
     assert!(alice.tracking().is_repo_tracked(&proj_id).unwrap());
 
     let (sender, receiver) = chan::bounded(1);
-    alice.command(Command::Untrack(proj_id, sender));
+    alice.command(Command::UntrackRepo(proj_id, sender));
     let policy_change = receiver
         .recv()
         .map_err(client::handle::Error::from)
@@ -556,9 +556,9 @@ fn test_refs_announcement_relay() {
     };
     let bob_inv = bob.inventory().unwrap();
 
-    alice.track(&bob_inv[0], tracking::Scope::All).unwrap();
-    alice.track(&bob_inv[1], tracking::Scope::All).unwrap();
-    alice.track(&bob_inv[2], tracking::Scope::All).unwrap();
+    alice.track_repo(&bob_inv[0], tracking::Scope::All).unwrap();
+    alice.track_repo(&bob_inv[1], tracking::Scope::All).unwrap();
+    alice.track_repo(&bob_inv[2], tracking::Scope::All).unwrap();
     alice.connect_to(&bob);
     alice.connect_to(&eve);
     alice.receive(&eve.addr(), Message::Subscribe(Subscribe::all()));
@@ -598,7 +598,7 @@ fn test_refs_announcement_no_subscribe() {
     let eve = Peer::new("eve", [9, 9, 9, 9], MockStorage::empty());
     let id = arbitrary::gen(1);
 
-    alice.track(&id, tracking::Scope::All).unwrap();
+    alice.track_repo(&id, tracking::Scope::All).unwrap();
     alice.connect_to(&bob);
     alice.connect_to(&eve);
     alice.receive(&bob.addr(), bob.refs_announcement(id));
@@ -857,11 +857,11 @@ fn test_push_and_pull() {
 
     // Bob tracks Alice's project.
     let (sender, _) = chan::bounded(1);
-    bob.command(service::Command::Track(proj_id, sender));
+    bob.command(service::Command::TrackRepo(proj_id, sender));
 
     // Eve tracks Alice's project.
     let (sender, _) = chan::bounded(1);
-    eve.command(service::Command::Track(proj_id, sender));
+    eve.command(service::Command::TrackRepo(proj_id, sender));
 
     let mut sim = Simulation::new(
         LocalTime::now(),

--- a/radicle-remote-helper/src/lib.rs
+++ b/radicle-remote-helper/src/lib.rs
@@ -108,8 +108,8 @@ pub fn run(profile: radicle::Profile) -> Result<(), Box<dyn std::error::Error + 
                         // Connect to local node and announce refs to the network.
                         // If our node is not running, we simply skip this step, as the
                         // refs will be announced eventually, when the node restarts.
-                        if let Ok(conn) = radicle::node::connect(&profile.node()) {
-                            conn.announce_refs(&url.repo)?;
+                        if let Ok(mut conn) = radicle::node::connect(&profile.node()) {
+                            conn.announce_refs(url.repo)?;
                         }
                     }
                 }

--- a/radicle-tools/src/rad-clone.rs
+++ b/radicle-tools/src/rad-clone.rs
@@ -11,8 +11,8 @@ fn main() -> anyhow::Result<()> {
 
     if let Some(id) = env::args().nth(1) {
         let id = Id::from_str(&id)?;
-        let node = radicle::node::connect(profile.node())?;
-        let repo = radicle::rad::clone(id, &cwd, &signer, &profile.storage, &node)?;
+        let mut node = radicle::node::connect(profile.node())?;
+        let repo = radicle::rad::clone(id, &cwd, &signer, &profile.storage, &mut node)?;
 
         println!(
             "ok: project {id} cloned into `{}`",

--- a/radicle-tools/src/rad-push.rs
+++ b/radicle-tools/src/rad-push.rs
@@ -16,7 +16,7 @@ fn main() -> anyhow::Result<()> {
     let sigrefs = project.sign_refs(&signer)?;
     let head = project.set_head()?;
 
-    radicle::node::connect(&profile.node())?.announce_refs(&id)?;
+    radicle::node::connect(&profile.node())?.announce_refs(id)?;
 
     println!("head: {}", head);
     println!("ok: {}", sigrefs.signature);

--- a/radicle/src/node.rs
+++ b/radicle/src/node.rs
@@ -1,12 +1,13 @@
 mod features;
 
-use std::io;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
+use std::{io, net};
 
 use crate::crypto::PublicKey;
 use crate::identity::Id;
+use crossbeam_channel as chan;
 
 pub use features::Features;
 
@@ -27,22 +28,38 @@ pub enum Error {
     EmptyResponse { cmd: &'static str },
 }
 
+/// A handle to send commands to the node or request information.
 pub trait Handle {
-    /// Fetch a project from the network. Fails if the project isn't tracked.
-    fn fetch(&self, id: &Id) -> Result<(), Error>;
-    /// Start tracking the given node. If the node is already tracked,
-    /// updates the alias if necessary.
-    fn track_node(&self, id: &NodeId, alias: Option<&str>) -> Result<bool, Error>;
-    /// Start tracking the given repository.
-    fn track_repo(&self, id: &Id) -> Result<bool, Error>;
+    /// The result of a fetch request.
+    type FetchLookup;
+    /// The peer session type.
+    type Session;
+    /// The error returned by all methods.
+    type Error: std::error::Error;
+
+    /// Wait for the node's listening socket to be bound.
+    fn listening(&self) -> Result<net::SocketAddr, Self::Error>;
+    /// Retrieve or update the project from network.
+    fn fetch(&mut self, id: Id) -> Result<Self::FetchLookup, Self::Error>;
+    /// Start tracking the given project. Doesn't do anything if the project is already
+    /// tracked.
+    fn track_repo(&mut self, id: Id) -> Result<bool, Self::Error>;
+    /// Start tracking the given node.
+    fn track_node(&mut self, id: NodeId, alias: Option<String>) -> Result<bool, Self::Error>;
+    /// Untrack the given project and delete it from storage.
+    fn untrack_repo(&mut self, id: Id) -> Result<bool, Self::Error>;
     /// Untrack the given node.
-    fn untrack_node(&self, id: &NodeId) -> Result<bool, Error>;
-    /// Untrack the given repository and delete it from storage.
-    fn untrack_repo(&self, id: &Id) -> Result<bool, Error>;
-    /// Notify the network that we have new refs.
-    fn announce_refs(&self, id: &Id) -> Result<(), Error>;
-    /// Ask the node to shutdown.
-    fn shutdown(self) -> Result<(), Error>;
+    fn untrack_node(&mut self, id: NodeId) -> Result<bool, Self::Error>;
+    /// Notify the client that a project has been updated.
+    fn announce_refs(&mut self, id: Id) -> Result<(), Self::Error>;
+    /// Ask the client to shutdown.
+    fn shutdown(self) -> Result<(), Self::Error>;
+    /// Query the routing table entries.
+    fn routing(&self) -> Result<chan::Receiver<(Id, NodeId)>, Self::Error>;
+    /// Query the peer session state.
+    fn sessions(&self) -> Result<chan::Receiver<(NodeId, Self::Session)>, Self::Error>;
+    /// Query the inventory.
+    fn inventory(&self) -> Result<chan::Receiver<Id>, Self::Error>;
 }
 
 /// Public node & device identifier.
@@ -80,7 +97,11 @@ impl Node {
 }
 
 impl Handle for Node {
-    fn fetch(&self, id: &Id) -> Result<(), Error> {
+    type Session = ();
+    type FetchLookup = ();
+    type Error = Error;
+
+    fn fetch(&mut self, id: Id) -> Result<(), Error> {
         for line in self.call("fetch", &[id])? {
             let line = line?;
             log::debug!("node: {}", line);
@@ -88,9 +109,9 @@ impl Handle for Node {
         Ok(())
     }
 
-    fn track_node(&self, id: &NodeId, alias: Option<&str>) -> Result<bool, Error> {
+    fn track_node(&mut self, id: NodeId, alias: Option<String>) -> Result<bool, Error> {
         let id = id.to_human();
-        let mut line = if let Some(alias) = alias {
+        let mut line = if let Some(alias) = alias.as_deref() {
             self.call("track-node", &[id.as_str(), alias])
         } else {
             self.call("track-node", &[id.as_str()])
@@ -111,7 +132,7 @@ impl Handle for Node {
         }
     }
 
-    fn track_repo(&self, id: &Id) -> Result<bool, Error> {
+    fn track_repo(&mut self, id: Id) -> Result<bool, Error> {
         let mut line = self.call("track-repo", &[id])?;
         let line = line
             .next()
@@ -129,7 +150,7 @@ impl Handle for Node {
         }
     }
 
-    fn untrack_node(&self, id: &NodeId) -> Result<bool, Error> {
+    fn untrack_node(&mut self, id: NodeId) -> Result<bool, Error> {
         let mut line = self.call("untrack-node", &[id])?;
         let line = line.next().ok_or(Error::EmptyResponse {
             cmd: "untrack-node",
@@ -147,7 +168,7 @@ impl Handle for Node {
         }
     }
 
-    fn untrack_repo(&self, id: &Id) -> Result<bool, Error> {
+    fn untrack_repo(&mut self, id: Id) -> Result<bool, Error> {
         let mut line = self.call("untrack-repo", &[id])?;
         let line = line.next().ok_or(Error::EmptyResponse {
             cmd: "untrack-repo",
@@ -165,12 +186,28 @@ impl Handle for Node {
         }
     }
 
-    fn announce_refs(&self, id: &Id) -> Result<(), Error> {
+    fn announce_refs(&mut self, id: Id) -> Result<(), Error> {
         for line in self.call("announce-refs", &[id])? {
             let line = line?;
             log::debug!("node: {}", line);
         }
         Ok(())
+    }
+
+    fn routing(&self) -> Result<chan::Receiver<(Id, NodeId)>, Error> {
+        todo!();
+    }
+
+    fn sessions(&self) -> Result<chan::Receiver<(NodeId, Self::Session)>, Error> {
+        todo!();
+    }
+
+    fn listening(&self) -> Result<net::SocketAddr, Error> {
+        todo!();
+    }
+
+    fn inventory(&self) -> Result<chan::Receiver<Id>, Error> {
+        todo!();
     }
 
     fn shutdown(self) -> Result<(), Error> {

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -199,7 +199,7 @@ pub fn clone<P: AsRef<Path>, G: Signer, S: storage::WriteStorage, H: node::Handl
     storage: &S,
     handle: &H,
 ) -> Result<git2::Repository, CloneError> {
-    let _ = handle.track(&proj)?;
+    let _ = handle.track_repo(&proj)?;
     let _ = handle.fetch(&proj)?;
     let _ = fork(proj, signer, storage)?;
     let working = checkout(proj, signer.public_key(), path, storage)?;

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -197,10 +197,13 @@ pub fn clone<P: AsRef<Path>, G: Signer, S: storage::WriteStorage, H: node::Handl
     path: P,
     signer: &G,
     storage: &S,
-    handle: &H,
-) -> Result<git2::Repository, CloneError> {
-    let _ = handle.track_repo(&proj)?;
-    let _ = handle.fetch(&proj)?;
+    handle: &mut H,
+) -> Result<git2::Repository, CloneError>
+where
+    CloneError: From<H::Error>,
+{
+    let _ = handle.track_repo(proj)?;
+    let _ = handle.fetch(proj)?;
     let _ = fork(proj, signer, storage)?;
     let working = checkout(proj, signer.public_key(), path, storage)?;
 


### PR DESCRIPTION
I'm not super happy with the proliferation of `track_repo`, `track_node` etc., but I think it's ok for now. I'd like to refactor at some point once it's clearer what we need, and once we find a nice abstraction for it.