### PR TITLE
Manage project delegates iff threshold = 1

### DIFF
--- a/radicle-cli/examples/rad-delegate.md
+++ b/radicle-cli/examples/rad-delegate.md
@@ -1,0 +1,46 @@
+Delegates are the authorized keys that can manage a project's
+metadata, including adding a new delegate.
+
+Let's list the current set of delegates for a project.
+
+```
+$ rad delegate list rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+[
+  "did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi"
+]
+```
+
+We want to add a new maintainer to the project to help out with the
+work.
+
+```
+$ rad delegate add z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG --to rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+Added delegate 'did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG'
+ok Update successful!
+```
+
+Let's convince ourselves that there's another delegate.
+
+```
+$ rad delegate list rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+[
+  "did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi",
+  "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"
+]
+```
+
+And finally, we no longer want to be part of the project so we pass on
+the torch and remove ourselves from the delegate set.
+
+```
+$ rad delegate remove z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi --to rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+Removed delegate 'did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi'
+ok Update successful!
+```
+
+```
+$ rad delegate list rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+[
+  "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"
+]
+```

--- a/radicle-cli/src/commands.rs
+++ b/radicle-cli/src/commands.rs
@@ -6,6 +6,8 @@ pub mod rad_auth;
 pub mod rad_checkout;
 #[path = "commands/clone.rs"]
 pub mod rad_clone;
+#[path = "commands/delegate.rs"]
+pub mod rad_delegate;
 #[path = "commands/edit.rs"]
 pub mod rad_edit;
 #[path = "commands/help.rs"]

--- a/radicle-cli/src/commands/checkout.rs
+++ b/radicle-cli/src/commands/checkout.rs
@@ -84,7 +84,7 @@ pub fn execute(options: Options, profile: &Profile) -> anyhow::Result<PathBuf> {
         .identity_of(profile.id())
         .context("project could not be found in local storage")?;
     let payload = doc.project()?;
-    let path = PathBuf::from(payload.name.clone());
+    let path = PathBuf::from(payload.name().clone());
 
     if path.exists() {
         anyhow::bail!("the local path {:?} already exists", path.as_path());
@@ -93,7 +93,7 @@ pub fn execute(options: Options, profile: &Profile) -> anyhow::Result<PathBuf> {
     term::headline(&format!(
         "Initializing local checkout for 🌱 {} ({})",
         term::format::highlight(options.id),
-        payload.name,
+        payload.name(),
     ));
 
     let spinner = term::spinner("Performing checkout...");
@@ -119,7 +119,7 @@ pub fn execute(options: Options, profile: &Profile) -> anyhow::Result<PathBuf> {
     setup_remotes(
         project::SetupRemote {
             project: id,
-            default_branch: payload.default_branch,
+            default_branch: payload.default_branch().clone(),
             repo: &repo,
             fetch: true,
             tracking: true,

--- a/radicle-cli/src/commands/clone.rs
+++ b/radicle-cli/src/commands/clone.rs
@@ -97,7 +97,7 @@ pub fn clone(id: Id, _interactive: Interactive, ctx: impl term::Context) -> anyh
         .map_err(|_e| anyhow!("couldn't load project {} from local state", id))?;
     let proj = doc.project()?;
 
-    let path = Path::new(&proj.name);
+    let path = Path::new(proj.name());
     let repo = rad::checkout(id, profile.id(), path, &profile.storage)?;
     let delegates = doc
         .delegates
@@ -105,7 +105,7 @@ pub fn clone(id: Id, _interactive: Interactive, ctx: impl term::Context) -> anyh
         .map(|d| **d)
         .filter(|id| id != profile.id())
         .collect::<Vec<_>>();
-    let default_branch = proj.default_branch.clone();
+    let default_branch = proj.default_branch().clone();
 
     // Setup tracking for project delegates.
     setup_remotes(

--- a/radicle-cli/src/commands/delegate.rs
+++ b/radicle-cli/src/commands/delegate.rs
@@ -1,0 +1,141 @@
+use std::ffi::OsString;
+use std::str::FromStr;
+
+use anyhow::{anyhow, Context as _};
+
+use radicle::identity::Id;
+use radicle_crypto::PublicKey;
+
+use crate::terminal as term;
+use crate::terminal::args::{Args, Error, Help};
+
+#[path = "delegate/add.rs"]
+mod add;
+#[path = "delegate/list.rs"]
+mod list;
+#[path = "delegate/remove.rs"]
+mod remove;
+
+pub const HELP: Help = Help {
+    name: "delegate",
+    description: "Manage the delegates of an identity",
+    version: env!("CARGO_PKG_VERSION"),
+    usage: r#"
+Usage
+
+    rad delegate (add|remove) <public key> [--to <id>]
+    rad delegate list [<id>]
+
+    The `add` and `remove` commands are limited to managing delegates
+    where the `threshold` for the quorum is exactly `1`. Otherwise,
+    the verification of the document will not be able to gather enough
+    signatures to pass the quorum.
+
+Options
+
+    --help              Print help
+"#,
+};
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum OperationName {
+    Add,
+    Remove,
+    #[default]
+    List,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Operation {
+    Add { id: Option<Id>, key: PublicKey },
+    Remove { id: Option<Id>, key: PublicKey },
+    List { id: Option<Id> },
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Options {
+    pub op: Operation,
+}
+
+impl Args for Options {
+    fn from_args(args: Vec<OsString>) -> anyhow::Result<(Self, Vec<OsString>)> {
+        use lexopt::prelude::*;
+
+        let mut parser = lexopt::Parser::from_args(args);
+        let mut id: Option<Id> = None;
+        let mut op: Option<OperationName> = None;
+        let mut key: Option<PublicKey> = None;
+
+        while let Some(arg) = parser.next()? {
+            match arg {
+                Long("help") => {
+                    return Err(Error::Help.into());
+                }
+                Long("to") => {
+                    id = Some(parser.value()?.parse::<Id>()?);
+                }
+                Value(val) if op.is_none() => match val.to_string_lossy().as_ref() {
+                    "a" | "add" => op = Some(OperationName::Add),
+                    "r" | "remove" => op = Some(OperationName::Remove),
+                    "l" | "list" => op = Some(OperationName::List),
+
+                    unknown => anyhow::bail!("unknown operation '{}'", unknown),
+                },
+                Value(val) if op.is_some() => {
+                    let val = val.to_string_lossy();
+
+                    match op {
+                        Some(OperationName::Add) | Some(OperationName::Remove) => {
+                            if let Ok(val) = PublicKey::from_str(&val) {
+                                key = Some(val);
+                            } else {
+                                return Err(anyhow!("invalid Public Key '{}'", val));
+                            }
+                        }
+                        Some(OperationName::List) => {
+                            if let Ok(val) = Id::from_str(&val) {
+                                id = Some(val);
+                            } else {
+                                return Err(anyhow!("invalid Project ID '{}'", val));
+                            }
+                        }
+                        None => continue,
+                    }
+                }
+                _ => return Err(anyhow!(arg.unexpected())),
+            }
+        }
+
+        let op = match op.unwrap_or_default() {
+            OperationName::List => Operation::List { id },
+            OperationName::Add => Operation::Add {
+                id,
+                key: key.ok_or_else(|| anyhow!("a delegate key must be provided"))?,
+            },
+            OperationName::Remove => Operation::Remove {
+                id,
+                key: key.ok_or_else(|| anyhow!("a delegate key must be provided"))?,
+            },
+        };
+
+        Ok((Options { op }, vec![]))
+    }
+}
+
+pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
+    let profile = ctx.profile()?;
+    let storage = &profile.storage;
+
+    match options.op {
+        Operation::Add { id, key } => add::run(&profile, storage, get_id(id)?, key)?,
+        Operation::Remove { id, key } => remove::run(&profile, storage, get_id(id)?, &key)?,
+        Operation::List { id } => list::run(&profile, storage, get_id(id)?)?,
+    }
+
+    Ok(())
+}
+
+fn get_id(id: Option<Id>) -> anyhow::Result<Id> {
+    id.or_else(|| radicle::rad::cwd().ok().map(|(_, id)| id))
+        .context("Couldn't get ID from either command line or cwd")
+}

--- a/radicle-cli/src/commands/delegate/add.rs
+++ b/radicle-cli/src/commands/delegate/add.rs
@@ -1,0 +1,51 @@
+use anyhow::Context as _;
+use radicle::{
+    prelude::{Did, Id},
+    storage::{WriteRepository as _, WriteStorage},
+    Profile,
+};
+use radicle_crypto::PublicKey;
+
+use crate::terminal as term;
+
+pub fn run<S>(profile: &Profile, storage: &S, id: Id, key: PublicKey) -> anyhow::Result<()>
+where
+    S: WriteStorage,
+{
+    let signer = term::signer(profile)?;
+    let me = signer.public_key();
+
+    let mut project = storage
+        .get(&profile.public_key, id)?
+        .context("No project with such ID exists")?;
+
+    let repo = storage.repository(id)?;
+
+    if !project.is_delegate(me) {
+        return Err(anyhow::anyhow!(
+            "'{}' is not a delegate of the project, only a delegate may add this key",
+            me
+        ));
+    }
+
+    if project.threshold > 1 {
+        return Err(anyhow::anyhow!("project threshold > 1"));
+    }
+
+    if project.delegate(&key) {
+        project.sign(&signer).and_then(|(_, sig)| {
+            project.update(
+                signer.public_key(),
+                "Updated payload",
+                &[(signer.public_key(), sig)],
+                repo.raw(),
+            )
+        })?;
+        term::info!("Added delegate '{}'", Did::from(key));
+        term::success!("Update successful!");
+        Ok(())
+    } else {
+        term::info!("the delegate for '{}' already exists", key);
+        Ok(())
+    }
+}

--- a/radicle-cli/src/commands/delegate/list.rs
+++ b/radicle-cli/src/commands/delegate/list.rs
@@ -1,0 +1,16 @@
+use anyhow::Context as _;
+use radicle::{prelude::Id, storage::ReadStorage, Profile};
+
+use crate::terminal as term;
+
+pub fn run<S>(profile: &Profile, storage: &S, id: Id) -> anyhow::Result<()>
+where
+    S: ReadStorage,
+{
+    let project = storage
+        .get(&profile.public_key, id)?
+        .context("No project with such ID exists")?;
+
+    term::info!("{}", serde_json::to_string_pretty(&project.delegates)?);
+    Ok(())
+}

--- a/radicle-cli/src/commands/delegate/remove.rs
+++ b/radicle-cli/src/commands/delegate/remove.rs
@@ -1,0 +1,54 @@
+use anyhow::Context as _;
+use radicle::{
+    prelude::Id,
+    storage::{WriteRepository as _, WriteStorage},
+    Profile,
+};
+use radicle_crypto::PublicKey;
+
+use crate::terminal as term;
+
+pub fn run<S>(profile: &Profile, storage: &S, id: Id, key: &PublicKey) -> anyhow::Result<()>
+where
+    S: WriteStorage,
+{
+    let signer = term::signer(profile)?;
+    let me = signer.public_key();
+
+    let mut project = storage
+        .get(&profile.public_key, id)?
+        .context("No project with such ID exists")?;
+
+    let repo = storage.repository(id)?;
+
+    if !project.is_delegate(me) {
+        return Err(anyhow::anyhow!(
+            "'{}' is not a delegate of the project, only a delegate may remove this key",
+            me
+        ));
+    }
+
+    if project.threshold > 1 {
+        return Err(anyhow::anyhow!("project threshold > 1"));
+    }
+
+    match project.rescind(key)? {
+        Some(delegate) => {
+            project.sign(&signer).and_then(|(_, sig)| {
+                project.update(
+                    signer.public_key(),
+                    "Updated payload",
+                    &[(signer.public_key(), sig)],
+                    repo.raw(),
+                )
+            })?;
+            term::info!("Removed delegate '{}'", delegate);
+            term::success!("Update successful!");
+            Ok(())
+        }
+        None => {
+            term::info!("the delegate for '{}' did not exist", key);
+            Ok(())
+        }
+    }
+}

--- a/radicle-cli/src/commands/init.rs
+++ b/radicle-cli/src/commands/init.rs
@@ -205,7 +205,7 @@ pub fn init(options: Options, profile: &profile::Profile) -> anyhow::Result<()> 
 
             spinner.message(format!(
                 "Project {} created",
-                term::format::highlight(&proj.name)
+                term::format::highlight(proj.name())
             ));
             spinner.finish();
 
@@ -214,13 +214,13 @@ pub fn init(options: Options, profile: &profile::Profile) -> anyhow::Result<()> 
                 term::blank();
             }
 
-            if options.set_upstream || git::branch_remote(&repo, &proj.default_branch).is_err() {
+            if options.set_upstream || git::branch_remote(&repo, proj.default_branch()).is_err() {
                 // Setup eg. `master` -> `rad/master`
                 radicle::git::set_upstream(
                     &repo,
                     &radicle::rad::REMOTE_NAME,
-                    &proj.default_branch,
-                    &radicle::git::refs::workdir::branch(&proj.default_branch),
+                    proj.default_branch(),
+                    &radicle::git::refs::workdir::branch(proj.default_branch()),
                 )?;
             }
 

--- a/radicle-cli/src/commands/ls.rs
+++ b/radicle-cli/src/commands/ls.rs
@@ -3,7 +3,6 @@ use std::ffi::OsString;
 use crate::terminal as term;
 use crate::terminal::args::{Args, Error, Help};
 
-use radicle::prelude::*;
 use radicle::storage::{ReadRepository, WriteStorage};
 
 pub const HELP: Help = Help {
@@ -50,13 +49,13 @@ pub fn run(_options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     storage.projects()?.into_iter().for_each(|id| {
         let Ok(repo) = storage.repository(id) else { return };
         let Ok((_, head)) = repo.head() else { return };
-        let Ok(Project { name, description, .. }) = repo.project_of(profile.id()) else { return };
+        let Ok(proj) = repo.project_of(profile.id()) else { return };
         let head = term::format::oid(head);
         table.push([
-            term::format::bold(name),
+            term::format::bold(proj.name()),
             term::format::tertiary(id),
             term::format::secondary(head),
-            term::format::italic(description),
+            term::format::italic(proj.description()),
         ]);
     });
     table.render();

--- a/radicle-cli/src/commands/patch/create.rs
+++ b/radicle-cli/src/commands/patch/create.rs
@@ -47,7 +47,7 @@ pub fn run(
 
     term::headline(&format!(
         "🌱 Creating patch for {}",
-        term::format::highlight(&project.name)
+        term::format::highlight(project.name())
     ));
 
     let signer = term::signer(profile)?;
@@ -92,7 +92,7 @@ pub fn run(
     // branch, as well as your own (eg. `rad/master`).
     let mut spinner = term::spinner("Analyzing remotes...");
     let targets =
-        common::find_merge_targets(&head_oid, project.default_branch.as_refstr(), storage)?;
+        common::find_merge_targets(&head_oid, project.default_branch().as_refstr(), storage)?;
 
     // eg. `refs/namespaces/<peer>/refs/heads/master`
     let (target_peer, target_oid) = match targets.not_merged.as_slice() {
@@ -177,7 +177,7 @@ pub fn run(
     term::info!(
         "{}/{} ({}) <- {}/{} ({})",
         term::format::dim(target_peer.id),
-        term::format::highlight(project.default_branch.to_string()),
+        term::format::highlight(project.default_branch().to_string()),
         term::format::secondary(term::format::oid(*target_oid)),
         term::format::dim(term::format::node(patches.public_key())),
         term::format::highlight(head_branch.to_string()),

--- a/radicle-cli/src/commands/track.rs
+++ b/radicle-cli/src/commands/track.rs
@@ -98,7 +98,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
 
     term::info!(
         "Establishing 🌱 tracking relationship for {}",
-        term::format::highlight(project.name)
+        term::format::highlight(project.name())
     );
     term::blank();
 

--- a/radicle-cli/src/commands/untrack.rs
+++ b/radicle-cli/src/commands/untrack.rs
@@ -73,13 +73,13 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     if untrack(id, &profile)? {
         term::success!(
             "Tracking relationships for {} ({}) removed",
-            term::format::highlight(project.name),
+            term::format::highlight(project.name()),
             &id.to_human()
         );
     } else {
         term::info!(
             "Tracking relationships for {} ({}) doesn't exist",
-            term::format::highlight(project.name),
+            term::format::highlight(project.name()),
             &id.to_human()
         );
     }

--- a/radicle-cli/src/main.rs
+++ b/radicle-cli/src/main.rs
@@ -134,6 +134,14 @@ fn run_other(exe: &str, args: &[OsString]) -> Result<(), Option<anyhow::Error>> 
                 args.to_vec(),
             );
         }
+        "delegate" => {
+            term::run_command_args::<rad_delegate::Options, _>(
+                rad_delegate::HELP,
+                "Delegate",
+                rad_delegate::run,
+                args.to_vec(),
+            );
+        }
         "edit" => {
             term::run_command_args::<rad_edit::Options, _>(
                 rad_edit::HELP,

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -72,3 +72,18 @@ fn rad_init() {
 
     test("examples/rad-init.md", Some(&profile)).unwrap();
 }
+
+#[test]
+fn rad_delegate() {
+    let home = tempfile::tempdir().unwrap();
+    let working = tempfile::tempdir().unwrap();
+    let profile = profile(home.path());
+
+    // Setup a test repository.
+    fixtures::repository(working.path());
+    // Navigate to repository.
+    env::set_current_dir(working.path()).unwrap();
+
+    test("examples/rad-init.md", Some(&profile)).unwrap();
+    test("examples/rad-delegate.md", Some(&profile)).unwrap();
+}

--- a/radicle/src/identity.rs
+++ b/radicle/src/identity.rs
@@ -213,7 +213,7 @@ mod test {
             .unwrap();
 
         // Add Bob as a delegate, and sign it.
-        doc.delegate(*bob.public_key());
+        doc.delegate(bob.public_key());
         doc.threshold = 2;
         doc.sign(&alice)
             .and_then(|(_, sig)| {
@@ -227,7 +227,7 @@ mod test {
             .unwrap();
 
         // Add Eve as a delegate, and sign it.
-        doc.delegate(*eve.public_key());
+        doc.delegate(eve.public_key());
         doc.sign(&alice)
             .and_then(|(_, alice_sig)| {
                 doc.sign(&bob).and_then(|(_, bob_sig)| {

--- a/radicle/src/identity.rs
+++ b/radicle/src/identity.rs
@@ -121,7 +121,7 @@ impl Identity<Untrusted> {
             let quorum = untrusted
                 .sigs
                 .iter()
-                .filter(|(key, _)| trusted.delegates.iter().any(|d| &**d == key))
+                .filter(|(key, _)| trusted.delegates.iter().any(|d| **d == **key))
                 .count();
             if quorum < trusted.threshold {
                 return Err(IdentityError::ThresholdNotReached(

--- a/radicle/src/identity.rs
+++ b/radicle/src/identity.rs
@@ -194,11 +194,12 @@ mod test {
         // want to have to create a repository object twice. Perhaps there should
         // be a way of getting a project from a repo.
         let mut doc = storage.get(alice.public_key(), id).unwrap().unwrap();
-        let mut prj = doc.project().unwrap();
+        let prj = doc.project().unwrap();
         let repo = storage.repository(id).unwrap();
 
         // Make a change to the description and sign it.
-        prj.description += "!";
+        let desc = prj.description().to_owned() + "!";
+        let prj = prj.update(None, desc, None).unwrap();
         doc.payload.insert(PayloadId::project(), prj.clone().into());
         doc.sign(&alice)
             .and_then(|(_, sig)| {
@@ -241,7 +242,8 @@ mod test {
             .unwrap();
 
         // Update description again with signatures by Eve and Bob.
-        prj.description += "?";
+        let desc = prj.description().to_owned() + "?";
+        let prj = prj.update(None, desc, None).unwrap();
         doc.payload.insert(PayloadId::project(), prj.into());
         let (current, head) = doc
             .sign(&bob)
@@ -271,6 +273,6 @@ mod test {
         assert_eq!(identity.doc, doc);
 
         let doc = storage.get(alice.public_key(), id).unwrap().unwrap();
-        assert_eq!(doc.project().unwrap().description, "Acme's repository!?");
+        assert_eq!(doc.project().unwrap().description(), "Acme's repository!?");
     }
 }

--- a/radicle/src/identity/did.rs
+++ b/radicle/src/identity/did.rs
@@ -14,7 +14,7 @@ pub enum DidError {
     PublicKey(#[from] crypto::PublicKeyError),
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]
 #[serde(into = "String", try_from = "String")]
 pub struct Did(crypto::PublicKey);
 
@@ -34,9 +34,15 @@ impl Did {
     }
 }
 
+impl From<&crypto::PublicKey> for Did {
+    fn from(key: &crypto::PublicKey) -> Self {
+        Self(*key)
+    }
+}
+
 impl From<crypto::PublicKey> for Did {
     fn from(key: crypto::PublicKey) -> Self {
-        Self(key)
+        (&key).into()
     }
 }
 

--- a/radicle/src/identity/doc.rs
+++ b/radicle/src/identity/doc.rs
@@ -1,6 +1,6 @@
 mod id;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::fmt::Write as _;
 use std::marker::PhantomData;
@@ -122,7 +122,7 @@ pub struct DocAt {
     /// The parsed document.
     pub doc: Doc<Verified>,
     /// The validated commit signatures.
-    pub sigs: Vec<(PublicKey, Signature)>,
+    pub sigs: HashMap<PublicKey, Signature>,
 }
 
 /// An identity document.

--- a/radicle/src/identity/project.rs
+++ b/radicle/src/identity/project.rs
@@ -1,4 +1,9 @@
-use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize, Serialize,
+};
 use thiserror::Error;
 
 use crate::crypto;
@@ -20,42 +25,171 @@ pub enum ProjectError {
 }
 
 /// A "project" payload in an identity document.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Project {
     /// Project name.
-    pub name: String,
+    name: String,
     /// Project description.
-    pub description: String,
+    description: String,
     /// Project default branch.
-    pub default_branch: BranchName,
+    default_branch: BranchName,
+}
+
+impl<'de> Deserialize<'de> for Project {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "camelCase")]
+        enum Field {
+            Name,
+            Description,
+            DefaultBranch,
+        }
+
+        struct ProjectVisitor;
+
+        impl<'de> Visitor<'de> for ProjectVisitor {
+            type Value = Project;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("xyz.radicle.project")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut name = None;
+                let mut description = None;
+                let mut default_branch = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Name => {
+                            if name.is_some() {
+                                return Err(de::Error::duplicate_field("name"));
+                            }
+                            name = Some(map.next_value()?);
+                        }
+                        Field::Description => {
+                            if description.is_some() {
+                                return Err(de::Error::duplicate_field("description"));
+                            }
+                            description = Some(map.next_value()?);
+                        }
+                        Field::DefaultBranch => {
+                            if default_branch.is_some() {
+                                return Err(de::Error::duplicate_field("defaultBranch"));
+                            }
+                            default_branch = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let name = name.ok_or_else(|| de::Error::missing_field("name"))?;
+                let description =
+                    description.ok_or_else(|| de::Error::missing_field("description"))?;
+                let default_branch =
+                    default_branch.ok_or_else(|| de::Error::missing_field("defaultBranch"))?;
+                Project::new(name, description, default_branch).map_err(|errs| {
+                    de::Error::custom(
+                        errs.into_iter()
+                            .map(|err| err.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    )
+                })
+            }
+        }
+        const FIELDS: &[&str] = &["name", "descrption", "defaultBranch"];
+        deserializer.deserialize_struct("Project", FIELDS, ProjectVisitor)
+    }
 }
 
 impl Project {
-    /// Validate the project data.
-    pub fn validate(&self) -> Result<(), ProjectError> {
-        if self.name.is_empty() {
-            return Err(ProjectError::Name("name cannot be empty"));
+    /// Create a new `Project` payload with the given values.
+    ///
+    /// These values are subject to validation and any errors are returned in a vector.
+    ///
+    /// # Validation Rules
+    ///
+    ///   * `name`'s length must not be empty and must not exceed 255.
+    ///   * `description`'s length must not exceed 255.
+    ///   * `default_branch`'s length must not be empty and must not exceed 255.
+    pub fn new(
+        name: String,
+        description: String,
+        default_branch: BranchName,
+    ) -> Result<Self, Vec<ProjectError>> {
+        let mut errs = Vec::new();
+
+        if name.is_empty() {
+            errs.push(ProjectError::Name("name cannot be empty"));
+        } else if name.len() > doc::MAX_STRING_LENGTH {
+            errs.push(ProjectError::Name("name cannot exceed 255 bytes"));
         }
-        if self.name.len() > doc::MAX_STRING_LENGTH {
-            return Err(ProjectError::Name("name cannot exceed 255 bytes"));
-        }
-        if self.description.len() > doc::MAX_STRING_LENGTH {
-            return Err(ProjectError::Description(
+
+        if description.len() > doc::MAX_STRING_LENGTH {
+            errs.push(ProjectError::Description(
                 "description cannot exceed 255 bytes",
             ));
         }
-        if self.default_branch.is_empty() {
-            return Err(ProjectError::DefaultBranch(
+
+        if default_branch.is_empty() {
+            errs.push(ProjectError::DefaultBranch(
                 "default branch cannot be empty",
-            ));
-        }
-        if self.default_branch.len() > doc::MAX_STRING_LENGTH {
-            return Err(ProjectError::DefaultBranch(
+            ))
+        } else if default_branch.len() > doc::MAX_STRING_LENGTH {
+            errs.push(ProjectError::DefaultBranch(
                 "default branch cannot exceed 255 bytes",
-            ));
+            ))
         }
-        Ok(())
+
+        if errs.is_empty() {
+            Ok(Self {
+                name,
+                description,
+                default_branch,
+            })
+        } else {
+            Err(errs)
+        }
+    }
+
+    /// Update the `Project` payload with new values, if provided.
+    ///
+    /// When any of the values are set to `None` then the original
+    /// value will be used, and so the value will pass validation.
+    ///
+    /// Otherwise, the new value is used and will be subject to the
+    /// original validation rules (see [`Project::new`]).
+    pub fn update(
+        self,
+        name: impl Into<Option<String>>,
+        description: impl Into<Option<String>>,
+        default_branch: impl Into<Option<BranchName>>,
+    ) -> Result<Self, Vec<ProjectError>> {
+        let name = name.into().unwrap_or(self.name);
+        let description = description.into().unwrap_or(self.description);
+        let default_branch = default_branch.into().unwrap_or(self.default_branch);
+        Self::new(name, description, default_branch)
+    }
+
+    #[inline]
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
+    #[inline]
+    pub fn description(&self) -> &String {
+        &self.description
+    }
+
+    #[inline]
+    pub fn default_branch(&self) -> &BranchName {
+        &self.default_branch
     }
 }
 

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -840,10 +840,10 @@ pub mod trailers {
         Signature(#[from] SignatureError),
     }
 
-    pub fn parse_signatures(msg: &str) -> Result<Vec<(PublicKey, Signature)>, Error> {
+    pub fn parse_signatures(msg: &str) -> Result<HashMap<PublicKey, Signature>, Error> {
         let trailers =
             git2::message_trailers_strs(msg).map_err(|_| Error::SignatureTrailerFormat)?;
-        let mut signatures = Vec::with_capacity(trailers.len());
+        let mut signatures = HashMap::with_capacity(trailers.len());
 
         for (key, val) in trailers.iter() {
             if key == SIGNATURE_TRAILER {
@@ -851,7 +851,7 @@ pub mod trailers {
                     let pk = PublicKey::from_str(pk)?;
                     let sig = Signature::from_str(sig)?;
 
-                    signatures.push((pk, sig));
+                    signatures.insert(pk, sig);
                 } else {
                     return Err(Error::SignatureTrailerFormat);
                 }

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -520,7 +520,7 @@ impl ReadRepository for Repository {
         let (_, doc) = self.project_identity()?;
         let doc = doc.verified()?;
         let project = doc.project()?;
-        let branch_ref = Qualified::from(lit::refs_heads(&project.default_branch));
+        let branch_ref = Qualified::from(lit::refs_heads(&project.default_branch()));
         let raw = self.raw();
 
         let mut heads = Vec::new();

--- a/radicle/src/test/arbitrary.rs
+++ b/radicle/src/test/arbitrary.rs
@@ -93,11 +93,7 @@ impl Arbitrary for Project {
             .try_into()
             .unwrap();
 
-        Project {
-            name,
-            description,
-            default_branch,
-        }
+        Project::new(name, description, default_branch).unwrap()
     }
 }
 


### PR DESCRIPTION
This series allows the adding, removing, and listing of delegates.

It's limited to projects that have a threshold of 1 since we need to be able to gather signatures for an identity that needs a higher threshold.

The update of an identity with a higher threshold will be tackled in a separate series.