### PR TITLE
Assign issues using rad command + improve client example tests

### DIFF
--- a/radicle-cli/examples/rad-issue.md
+++ b/radicle-cli/examples/rad-issue.md
@@ -1,0 +1,34 @@
+Project 'todo' items are called 'issue's.  They can be inspected and modified
+using the 'issue' subcommand.
+
+Let's say the new car you are designing with your peers has a problem with its flux capacitor.
+
+```
+$ rad issue new --title "flux capacitor underpowered" --description "Flux capacitor power requirements exceed current supply"
+```
+
+The issue is now listed under our project.
+
+```
+$ rad issue list
+de81d97d7fe07a80bfb339200c6af862d4526b6a "flux capacitor underpowered"
+```
+
+Great! Now we've documented the issue for ourselves and others.
+
+Just like with other project management systems, the issue can be assigned to
+others to work on.  This is to ensure work is not duplicated.
+
+Let's assign ourselves to this one.
+
+```
+$ rad assign de81d97d7fe07a80bfb339200c6af862d4526b6a z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad issue list
+de81d97d7fe07a80bfb339200c6af862d4526b6a "flux capacitor underpowered" z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+```
+
+Note: this can always be undone with the 'unassign' subcommand.
+
+```
+$ rad unassign de81d97d7fe07a80bfb339200c6af862d4526b6a z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+```

--- a/radicle-cli/src/commands.rs
+++ b/radicle-cli/src/commands.rs
@@ -1,3 +1,5 @@
+#[path = "commands/assign.rs"]
+pub mod rad_assign;
 #[path = "commands/auth.rs"]
 pub mod rad_auth;
 #[path = "commands/checkout.rs"]
@@ -32,5 +34,7 @@ pub mod rad_rm;
 pub mod rad_self;
 #[path = "commands/track.rs"]
 pub mod rad_track;
+#[path = "commands/unassign.rs"]
+pub mod rad_unassign;
 #[path = "commands/untrack.rs"]
 pub mod rad_untrack;

--- a/radicle-cli/src/commands/assign.rs
+++ b/radicle-cli/src/commands/assign.rs
@@ -1,0 +1,96 @@
+use std::ffi::OsString;
+use std::str::FromStr;
+
+use anyhow::anyhow;
+
+use crate::terminal as term;
+use crate::terminal::args;
+use radicle::cob;
+use radicle::cob::issue;
+use radicle::storage::WriteStorage;
+
+pub const HELP: args::Help = args::Help {
+    name: "assign",
+    description: "assign an issue",
+    version: env!("CARGO_PKG_VERSION"),
+    usage: r#"
+Usage
+
+    rad assign <issue> <peer>
+
+Options
+
+    --help      Print help
+"#,
+};
+
+#[derive(Debug)]
+pub struct Options {
+    pub id: issue::IssueId,
+    pub peer: cob::ActorId,
+}
+
+impl args::Args for Options {
+    fn from_args(args: Vec<OsString>) -> anyhow::Result<(Self, Vec<OsString>)> {
+        use lexopt::prelude::*;
+
+        let mut parser = lexopt::Parser::from_args(args);
+        let mut id: Option<issue::IssueId> = None;
+        let mut peer: Option<cob::ActorId> = None;
+
+        while let Some(arg) = parser.next()? {
+            match arg {
+                Long("help") => {
+                    return Err(args::Error::Help.into());
+                }
+                Value(ref val) => {
+                    if id.is_none() {
+                        let val = val.to_string_lossy();
+                        let Ok(val) = issue::IssueId::from_str(&val) else {
+                            return Err(anyhow!("invalid issue ID '{}'", val));
+                        };
+
+                        id = Some(val);
+                    } else if peer.is_none() {
+                        let val = val.to_string_lossy();
+                        let Ok(val) = cob::ActorId::from_str(&val) else {
+                            return Err(anyhow!("invalid peer ID '{}'", val));
+                        };
+
+                        peer = Some(val);
+                    } else {
+                        return Err(anyhow!(arg.unexpected()));
+                    }
+                }
+                _ => {
+                    return Err(anyhow!(arg.unexpected()));
+                }
+            }
+        }
+
+        Ok((
+            Options {
+                id: id.unwrap(),
+                peer: peer.unwrap(),
+            },
+            vec![],
+        ))
+    }
+}
+
+pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
+    let profile = ctx.profile()?;
+    let signer = term::signer(&profile)?;
+    let storage = &profile.storage;
+    let (_, id) = radicle::rad::cwd()?;
+    let repo = storage.repository(id)?;
+    let mut issues = issue::Issues::open(*signer.public_key(), &repo)?;
+
+    let mut issue = issues.get_mut(&options.id).map_err(|err| match err {
+        cob::store::Error::NotFound(_, _) => anyhow!("issue not found '{}'", options.id),
+        _ => err.into(),
+    })?;
+    issue.assign(vec![options.peer], &signer)?;
+
+    Ok(())
+}

--- a/radicle-cli/src/commands/issue.rs
+++ b/radicle-cli/src/commands/issue.rs
@@ -235,7 +235,17 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         Operation::List => {
             for result in issues.all()? {
                 let (id, issue, _) = result?;
-                println!("{} {}", id, issue.title());
+
+                let assigned: String = issue
+                    .assigned()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                if assigned.is_empty() {
+                    println!("{} \"{}\"", id, issue.title().escape_default());
+                } else {
+                    println!("{} {:?} {}", id, issue.title().escape_default(), &assigned,);
+                }
             }
         }
         Operation::Delete { id } => {

--- a/radicle-cli/src/commands/issue.rs
+++ b/radicle-cli/src/commands/issue.rs
@@ -233,6 +233,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
             }
         }
         Operation::List => {
+            let mut t = term::Table::new(term::table::TableOptions::default());
             for result in issues.all()? {
                 let (id, issue, _) = result?;
 
@@ -241,12 +242,13 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                     .map(|p| p.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
-                if assigned.is_empty() {
-                    println!("{} \"{}\"", id, issue.title().escape_default());
-                } else {
-                    println!("{} {:?} {}", id, issue.title().escape_default(), &assigned,);
-                }
+                t.push([
+                    id.to_string(),
+                    format!("{:?}", issue.title()),
+                    assigned.to_string(),
+                ]);
             }
+            t.render();
         }
         Operation::Delete { id } => {
             issues.remove(&id)?;

--- a/radicle-cli/src/commands/unassign.rs
+++ b/radicle-cli/src/commands/unassign.rs
@@ -1,0 +1,96 @@
+use std::ffi::OsString;
+use std::str::FromStr;
+
+use anyhow::anyhow;
+
+use crate::terminal as term;
+use crate::terminal::args::{Args, Error, Help};
+use radicle::cob;
+use radicle::cob::issue;
+use radicle::storage::WriteStorage;
+
+pub const HELP: Help = Help {
+    name: "unassign",
+    description: "unassign an issue",
+    version: env!("CARGO_PKG_VERSION"),
+    usage: r#"
+Usage
+
+    rad unassign <issue> <peer>
+
+Options
+
+    --help      Print help
+"#,
+};
+
+#[derive(Debug)]
+pub struct Options {
+    pub id: issue::IssueId,
+    pub peer: cob::ActorId,
+}
+
+impl Args for Options {
+    fn from_args(args: Vec<OsString>) -> anyhow::Result<(Self, Vec<OsString>)> {
+        use lexopt::prelude::*;
+
+        let mut parser = lexopt::Parser::from_args(args);
+        let mut id: Option<issue::IssueId> = None;
+        let mut peer: Option<cob::ActorId> = None;
+
+        while let Some(arg) = parser.next()? {
+            match arg {
+                Long("help") => {
+                    return Err(Error::Help.into());
+                }
+                Value(ref val) => {
+                    if id.is_none() {
+                        let val = val.to_string_lossy();
+                        let Ok(val) = issue::IssueId::from_str(&val) else {
+                            return Err(anyhow!("invalid issue ID '{}'", val));
+                        };
+
+                        id = Some(val);
+                    } else if peer.is_none() {
+                        let val = val.to_string_lossy();
+                        let Ok(val) = cob::ActorId::from_str(&val) else {
+                            return Err(anyhow!("invalid peer ID '{}'", val));
+                        };
+
+                        peer = Some(val);
+                    } else {
+                        return Err(anyhow!(arg.unexpected()));
+                    }
+                }
+                _ => {
+                    return Err(anyhow!(arg.unexpected()));
+                }
+            }
+        }
+
+        Ok((
+            Options {
+                id: id.unwrap(),
+                peer: peer.unwrap(),
+            },
+            vec![],
+        ))
+    }
+}
+
+pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
+    let profile = ctx.profile()?;
+    let signer = term::signer(&profile)?;
+    let storage = &profile.storage;
+    let (_, id) = radicle::rad::cwd()?;
+    let repo = storage.repository(id)?;
+    let mut issues = issue::Issues::open(*signer.public_key(), &repo)?;
+
+    let mut issue = issues.get_mut(&options.id).map_err(|err| match err {
+        cob::store::Error::NotFound(_, _) => anyhow!("issue '{}' not found", options.id),
+        _ => err.into(),
+    })?;
+    issue.unassign(vec![options.peer], &signer)?;
+
+    Ok(())
+}

--- a/radicle-cli/src/main.rs
+++ b/radicle-cli/src/main.rs
@@ -102,6 +102,14 @@ fn run(command: Command) -> Result<(), Option<anyhow::Error>> {
 
 fn run_other(exe: &str, args: &[OsString]) -> Result<(), Option<anyhow::Error>> {
     match exe {
+        "assign" => {
+            term::run_command_args::<rad_assign::Options, _>(
+                rad_assign::HELP,
+                "Assign",
+                rad_assign::run,
+                args.to_vec(),
+            );
+        }
         "auth" => {
             term::run_command_args::<rad_auth::Options, _>(
                 rad_auth::HELP,
@@ -235,6 +243,14 @@ fn run_other(exe: &str, args: &[OsString]) -> Result<(), Option<anyhow::Error>> 
                 rad_track::HELP,
                 "Track",
                 rad_track::run,
+                args.to_vec(),
+            );
+        }
+        "unassign" => {
+            term::run_command_args::<rad_unassign::Options, _>(
+                rad_unassign::HELP,
+                "Unassign",
+                rad_unassign::run,
                 args.to_vec(),
             );
         }

--- a/radicle-cli/src/terminal/table.rs
+++ b/radicle-cli/src/terminal/table.rs
@@ -59,10 +59,12 @@ impl<const W: usize> Table<W> {
                     .ok();
                 }
             }
+
+            let output = output.trim_end();
             println!(
                 "{}",
                 if let Some(width) = width {
-                    console::truncate_str(&output, width - 1, "…")
+                    console::truncate_str(output, width - 1, "…")
                 } else {
                     output.into()
                 }

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -10,7 +10,7 @@ use framework::TestFormula;
 /// Run a CLI test file.
 fn test(
     path: impl AsRef<Path>,
-    profile: Option<Profile>,
+    profile: Option<&Profile>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let base = Path::new(env!("CARGO_MANIFEST_DIR"));
     let tmp = tempfile::tempdir().unwrap();
@@ -44,6 +44,22 @@ fn rad_auth() {
 }
 
 #[test]
+fn rad_issue() {
+    let home = tempfile::tempdir().unwrap();
+    let working = tempfile::tempdir().unwrap();
+    let profile = profile(home.path());
+
+    // Setup a test repository.
+    fixtures::repository(working.path());
+    // Navigate to repository.
+    env::set_current_dir(working.path()).unwrap();
+    env::set_var(radicle_cob::git::RAD_COMMIT_TIME, "1671125284");
+
+    test("examples/rad-init.md", Some(&profile)).unwrap();
+    test("examples/rad-issue.md", Some(&profile)).unwrap();
+}
+
+#[test]
 fn rad_init() {
     let home = tempfile::tempdir().unwrap();
     let working = tempfile::tempdir().unwrap();
@@ -54,5 +70,5 @@ fn rad_init() {
     // Navigate to repository.
     env::set_current_dir(working.path()).unwrap();
 
-    test("examples/rad-init.md", Some(profile)).unwrap();
+    test("examples/rad-init.md", Some(&profile)).unwrap();
 }

--- a/radicle-cob/src/backend/git.rs
+++ b/radicle-cob/src/backend/git.rs
@@ -4,3 +4,8 @@
 // Linking Exception. For full terms see the included LICENSE file.
 
 pub mod change;
+
+/// Environment variable to set to overwrite the commit date for both the author and the committer.
+///
+/// The format must be a unix timestamp.
+pub const RAD_COMMIT_TIME: &str = "RAD_COMMIT_TIME";

--- a/radicle-cob/src/backend/git/change.rs
+++ b/radicle-cob/src/backend/git/change.rs
@@ -247,10 +247,8 @@ where
 
         #[cfg(debug_assertions)]
         if let Ok(s) = std::env::var(git::RAD_COMMIT_TIME) {
-            if let Ok(v) = s.trim().parse::<i64>() {
-                author.time = git_commit::author::Time::new(v, 0);
-                timestamp = v;
-            }
+            timestamp = s.trim().parse::<i64>().unwrap();
+            author.time = git_commit::author::Time::new(timestamp, 0);
         }
 
         let oid = Commit::new(


### PR DESCRIPTION
Introduce two changes:

 - Support command tool example tests by improving idempotence (https://github.com/radicle-dev/heartwood/pull/159/commits/9c5c0e89fdecb7a7c2ae98d039c7ddca67564f18)
 - Add assign/unassign subcommands (https://github.com/radicle-dev/heartwood/pull/159/commits/458fcaeff676c3faa61e181b1cecca8ff06e4c19)

Issue #148