### PR TITLE
Verify identity root commit signatures

### DIFF
--- a/radicle-cli/src/commands/inspect.rs
+++ b/radicle-cli/src/commands/inspect.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Context as _};
 use chrono::prelude::*;
 use json_color::{Color, Colorizer};
 
+use radicle::crypto::Unverified;
 use radicle::identity::Untrusted;
 use radicle::identity::{Doc, Id};
 use radicle::storage::{ReadRepository, ReadStorage, WriteStorage};
@@ -154,7 +155,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         for (counter, oid) in history.into_iter().rev().enumerate() {
             let oid = oid?.into();
             let tip = repo.commit(oid)?;
-            let blob = Doc::blob_at(oid, &repo)?;
+            let blob = Doc::<Unverified>::blob_at(oid, &repo)?;
             let content: serde_json::Value = serde_json::from_slice(blob.content())?;
             let timezone = if tip.time().sign() == '+' {
                 #[allow(deprecated)]

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -65,7 +65,7 @@ pub fn init<G: Signer>(
         default_branch: default_branch.clone(),
     };
     let doc = identity::Doc::initial(proj, delegate).verified()?;
-    let (project, _) = Repository::init(&doc, pk, storage)?;
+    let (project, _) = Repository::init(&doc, pk, storage, signer)?;
     let url = git::Url::from(project.id).with_namespace(*pk);
 
     git::configure_remote(repo, &REMOTE_NAME, &url)?;

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -347,7 +347,7 @@ impl Repository {
             }
         }
 
-        Doc::load_at(longest.into(), self)
+        Doc::<Unverified>::load_at(longest.into(), self)
             .map(|(doc, _)| (longest.into(), doc))
             .map_err(ProjectError::from)
     }

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -213,15 +213,21 @@ impl Repository {
     }
 
     /// Create the repository's identity branch.
-    pub fn init(
+    pub fn init<G: Signer>(
         doc: &Doc<Verified>,
         remote: &RemoteId,
         storage: &Storage,
+        signer: &G,
     ) -> Result<(Self, git::Oid), Error> {
         let (doc_oid, doc) = doc.encode()?;
         let id = Id::from(doc_oid);
         let repo = Self::open(paths::repository(storage, &id), id)?;
-        let oid = Doc::init(doc.as_slice(), remote, repo.raw())?;
+        let oid = Doc::init(
+            doc.as_slice(),
+            remote,
+            &[(signer.public_key(), signer.sign(&doc))],
+            repo.raw(),
+        )?;
 
         Ok((repo, oid))
     }


### PR DESCRIPTION
In RIP-2, we specify that identity document root commits must include the signature of all founding delegates.

This commit adds the required signatures during document creation and verifies them on load.

Signed-off-by: Alexis Sellier <alexis@radicle.xyz>