### PR TITLE
Allow for arbitrary COB history graph-traversal orders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,12 +907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,16 +1856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,10 +2114,10 @@ dependencies = [
  "git2",
  "log",
  "nonempty 0.8.1",
- "petgraph",
  "qcheck",
  "qcheck-macros",
  "radicle-crypto",
+ "radicle-dag",
  "radicle-git-ext",
  "serde",
  "serde_json",
@@ -2175,6 +2159,13 @@ dependencies = [
  "tempfile",
  "thiserror",
  "zeroize",
+]
+
+[[package]]
+name = "radicle-dag"
+version = "0.1.0"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "radicle-cli",
   "radicle-crdt",
   "radicle-crypto",
+  "radicle-dag",
   "radicle-httpd",
   "radicle-node",
   "radicle-remote-helper",

--- a/radicle-cob/Cargo.toml
+++ b/radicle-cob/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["radicle", "collaborative objects", "cob", "cobs"]
 [lib]
 
 [dependencies]
+fastrand = { version = "1.8.0" }
 git-commit = { version = "0.2" }
 git-ref-format = { version = "0.1" }
 git-trailers = { version = "0.1" }
 log = { version = "0.4.17" }
 nonempty = { version = "0.8.1", features = ["serialize"] }
-petgraph = { version = "0.5" }
 radicle-git-ext = { version = "0" }
 serde_json = { version = "1.0" }
 thiserror = { version = "1.0" }
@@ -32,6 +32,10 @@ features = ["vendored-libgit2"]
 path = "../radicle-crypto"
 version = "0.1"
 features = ["ssh"]
+
+[dependencies.radicle-dag]
+path = "../radicle-dag"
+version = "0.1"
 
 [dependencies.serde]
 version = "1.0"

--- a/radicle-cob/src/change_graph.rs
+++ b/radicle-cob/src/change_graph.rs
@@ -93,20 +93,7 @@ impl ChangeGraph {
         let (root, root_node) = roots.first().unwrap();
         let manifest = root_node.manifest.clone();
         let rng = fastrand::Rng::new();
-        let items = self.graph.sorted(rng).into_iter().map(|oid| {
-            let node = &self.graph[&oid];
-            let child_commits = node
-                .dependents
-                .iter()
-                .map(|e| *self.graph[e].id())
-                .collect::<Vec<_>>();
-
-            (&node.value, oid, child_commits)
-        });
-        let history = {
-            let root_change = &self.graph[*root];
-            evaluate(*root_change.id(), &self.graph, items)
-        };
+        let history = evaluate(*self.graph[*root].id(), &self.graph, rng);
 
         CollaborativeObject {
             manifest,

--- a/radicle-cob/src/history.rs
+++ b/radicle-cob/src/history.rs
@@ -105,12 +105,12 @@ impl History {
     where
         F: for<'r> FnMut(A, &'r EntryWithClock) -> ControlFlow<A, A>,
     {
-        let sorted = self.graph.sorted(fastrand::Rng::new());
-        #[allow(clippy::let_and_return)]
-        let items = sorted.iter().map(|idx| {
-            let entry = &self.graph[idx];
-            entry
-        });
+        let items = self
+            .graph
+            .sorted(fastrand::Rng::new())
+            .into_iter()
+            .map(|idx| &self.graph[&idx]);
+
         pruning_fold::pruning_fold(init, items, f)
     }
 

--- a/radicle-cob/src/history.rs
+++ b/radicle-cob/src/history.rs
@@ -60,8 +60,8 @@ impl History {
         };
         let mut entries = HashMap::new();
         entries.insert(id, EntryWithClock::from(root_entry));
-        let NewGraph { graph, indices } = create_petgraph(&id, &entries);
-        Self { graph, indices }
+
+        create_petgraph(&id, &entries)
     }
 
     pub fn new<Id>(root: Id, entries: HashMap<EntryId, EntryWithClock>) -> Result<Self, CreateError>
@@ -72,8 +72,7 @@ impl History {
         if !entries.contains_key(&root) {
             Err(CreateError::MissingRoot)
         } else {
-            let NewGraph { graph, indices } = create_petgraph(&root, &entries);
-            Ok(Self { graph, indices })
+            Ok(create_petgraph(&root, &entries))
         }
     }
 
@@ -160,15 +159,10 @@ impl History {
     }
 }
 
-struct NewGraph {
-    graph: petgraph::Graph<EntryWithClock, (), petgraph::Directed, u32>,
-    indices: HashMap<EntryId, petgraph::graph::NodeIndex<u32>>,
-}
-
 fn create_petgraph<'a>(
     root: &'a EntryId,
     entries: &'a HashMap<EntryId, EntryWithClock>,
-) -> NewGraph {
+) -> History {
     let mut graph = petgraph::Graph::new();
     let mut indices = HashMap::<EntryId, petgraph::graph::NodeIndex<u32>>::new();
     let root = entries.get(root).unwrap().clone();
@@ -185,5 +179,5 @@ fn create_petgraph<'a>(
             to_process.push(child.clone());
         }
     }
-    NewGraph { graph, indices }
+    History { graph, indices }
 }

--- a/radicle-cob/src/object/collaboration/info.rs
+++ b/radicle-cob/src/object/collaboration/info.rs
@@ -4,11 +4,8 @@
 // Linking Exception. For full terms see the included LICENSE file.
 
 //! [`ChangeGraphInfo`] provides a useful debugging structure for
-//! represnting a single [`crate::CollaborativeObject`]'s underlying
-//! change graph. This includes a [`ChangeGraphInfo::dotviz`] for
-//! describing the graph via [graphviz].
-//!
-//! [graphviz]: https://graphviz.org/
+//! representing a single [`crate::CollaborativeObject`]'s underlying
+//! change graph.
 
 use std::collections::BTreeSet;
 
@@ -22,8 +19,6 @@ use super::error;
 pub struct ChangeGraphInfo {
     /// The ID of the object
     pub object_id: ObjectId,
-    /// A graphviz description of the changegraph of the object
-    pub dotviz: String,
     /// The number of nodes in the change graph of the object
     pub number_of_nodes: u64,
     /// The "tips" of the change graph, i.e the object IDs pointed to by
@@ -54,7 +49,6 @@ where
     Ok(
         ChangeGraph::load(storage, tip_refs.iter(), typename, oid).map(|graph| ChangeGraphInfo {
             object_id: *oid,
-            dotviz: graph.graphviz(),
             number_of_nodes: graph.number_of_nodes(),
             tips: graph.tips(),
         }),

--- a/radicle-crypto/src/ssh/keystore.rs
+++ b/radicle-crypto/src/ssh/keystore.rs
@@ -5,7 +5,7 @@ use std::{fs, io};
 use thiserror::Error;
 use zeroize::Zeroizing;
 
-use crate::{keypair, KeyPair, PublicKey, SecretKey, SharedSecret, Signature, Signer, SignerError};
+use crate::{keypair, KeyPair, PublicKey, SecretKey, Signature, Signer, SignerError};
 
 /// A secret key passphrase.
 pub type Passphrase = Zeroizing<String>;
@@ -155,10 +155,10 @@ impl Signer for MemorySigner {
 #[cfg(feature = "cyphernet")]
 impl cyphernet::crypto::Ecdh for MemorySigner {
     type Pk = PublicKey;
-    type Secret = SharedSecret;
+    type Secret = crate::SharedSecret;
     type Err = ed25519_compact::Error;
 
-    fn ecdh(&self, other: &PublicKey) -> Result<SharedSecret, ed25519_compact::Error> {
+    fn ecdh(&self, other: &PublicKey) -> Result<crate::SharedSecret, ed25519_compact::Error> {
         let pk = ed25519_compact::x25519::PublicKey::from_ed25519(other)?;
         let sk = ed25519_compact::x25519::SecretKey::from_ed25519(&self.secret)?;
         let ss = pk.dh(&sk)?;

--- a/radicle-dag/Cargo.toml
+++ b/radicle-dag/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "radicle-dag"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fastrand = { version = "1.8.0" }

--- a/radicle-dag/src/lib.rs
+++ b/radicle-dag/src/lib.rs
@@ -1,0 +1,301 @@
+use std::{
+    borrow::Borrow,
+    collections::{HashMap, HashSet},
+    fmt,
+    hash::Hash,
+    ops::{Deref, Index},
+};
+
+/// A node in the graph.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Node<K: Eq + Hash, V> {
+    /// The node value, stored by the user.
+    pub value: V,
+    /// Nodes depended on.
+    pub dependencies: HashSet<K>,
+    /// Nodes depending on this node.
+    pub dependents: HashSet<K>,
+}
+
+impl<K: Eq + Hash, V> Borrow<V> for &Node<K, V> {
+    fn borrow(&self) -> &V {
+        &self.value
+    }
+}
+
+impl<K: Eq + Hash, V> Deref for Node<K, V> {
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+/// A directed acyclic graph.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Dag<K: Eq + Hash, V> {
+    graph: HashMap<K, Node<K, V>>,
+    tips: HashSet<K>,
+    roots: HashSet<K>,
+}
+
+impl<K: Eq + Copy + Hash, V> Dag<K, V> {
+    /// Create a new empty DAG.
+    pub fn new() -> Self {
+        Self {
+            graph: HashMap::new(),
+            tips: HashSet::new(),
+            roots: HashSet::new(),
+        }
+    }
+
+    /// Check whether there are any nodes in the graph.
+    pub fn is_empty(&self) -> bool {
+        self.graph.is_empty()
+    }
+
+    /// Return the number of nodes in the graph.
+    pub fn len(&self) -> usize {
+        self.graph.len()
+    }
+
+    /// Add a node to the graph.
+    pub fn node(&mut self, key: K, value: V) -> Option<Node<K, V>> {
+        self.tips.insert(key);
+        self.roots.insert(key);
+        self.graph.insert(
+            key,
+            Node {
+                value,
+                dependencies: HashSet::new(),
+                dependents: HashSet::new(),
+            },
+        )
+    }
+
+    /// Add a dependency from one node to the other.
+    pub fn dependency(&mut self, from: K, to: K) {
+        if let Some(node) = self.graph.get_mut(&from) {
+            node.dependencies.insert(to);
+            self.roots.remove(&from);
+        }
+        if let Some(node) = self.graph.get_mut(&to) {
+            node.dependents.insert(from);
+            self.tips.remove(&to);
+        }
+    }
+
+    /// Get a node.
+    pub fn get(&self, key: &K) -> Option<&Node<K, V>> {
+        self.graph.get(key)
+    }
+
+    /// Check whether there is a dependency between two nodes.
+    pub fn has_dependency(&self, from: &K, to: &K) -> bool {
+        self.graph
+            .get(from)
+            .map(|n| n.dependencies.contains(to))
+            .unwrap_or_default()
+    }
+
+    /// Get the graph's root nodes, ie. nodes which don't depend on other nodes.
+    pub fn roots(&self) -> impl Iterator<Item = (&K, &Node<K, V>)> + '_ {
+        self.roots
+            .iter()
+            .filter_map(|k| self.graph.get(k).map(|n| (k, n)))
+    }
+
+    /// Get the graph's tip nodes, ie. nodes which aren't depended on by other nodes.
+    pub fn tips(&self) -> impl Iterator<Item = (&K, &Node<K, V>)> + '_ {
+        self.tips
+            .iter()
+            .filter_map(|k| self.graph.get(k).map(|n| (k, n)))
+    }
+
+    /// Return a topological ordering of the graph's nodes, using the given RNG.
+    /// Graphs with more than one partial order will return an arbitrary topological ordering.
+    ///
+    /// Calling this function over and over will eventually yield all possible orderings.
+    pub fn sorted(&self, rng: fastrand::Rng) -> Vec<K> {
+        let mut order = Vec::new(); // Stores the topological order.
+        let mut visited = HashSet::new(); // Nodes that have been visited.
+        let mut keys = self.graph.keys().collect::<Vec<_>>();
+
+        rng.shuffle(&mut keys);
+
+        for node in keys {
+            self.visit(node, &mut visited, &mut order);
+        }
+        order
+    }
+
+    /// Add nodes recursively to the topological order, starting from the given node.
+    fn visit(&self, key: &K, visited: &mut HashSet<K>, order: &mut Vec<K>) {
+        if visited.contains(key) {
+            return;
+        }
+        visited.insert(*key);
+
+        // Recursively visit all of the node's dependencies.
+        if let Some(node) = self.graph.get(key) {
+            for dependency in &node.dependencies {
+                self.visit(dependency, visited, order);
+            }
+        }
+        // Add the node to the topological order.
+        order.push(*key);
+    }
+}
+
+impl<K: Eq + Copy + Hash + fmt::Debug, V> Index<&K> for Dag<K, V> {
+    type Output = Node<K, V>;
+
+    fn index(&self, key: &K) -> &Self::Output {
+        self.get(key)
+            .unwrap_or_else(|| panic!("Dag::index: node {:?} not found in graph", key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_len() {
+        let mut dag = Dag::new();
+
+        dag.node(0, ());
+        dag.node(1, ());
+        dag.node(2, ());
+
+        assert_eq!(dag.len(), 3);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let mut dag = Dag::new();
+        assert!(dag.is_empty());
+
+        dag.node(0, ());
+        assert!(!dag.is_empty());
+    }
+
+    #[test]
+    fn test_dependencies() {
+        let mut dag = Dag::new();
+
+        dag.node(0, ());
+        dag.node(1, ());
+        dag.dependency(0, 1);
+
+        assert!(dag.has_dependency(&0, &1));
+        assert!(!dag.has_dependency(&1, &0));
+    }
+
+    #[test]
+    fn test_get() {
+        let mut dag = Dag::new();
+
+        dag.node(0, "rad");
+        dag.node(1, "dar");
+
+        assert_eq!(dag[&0].value, "rad");
+        assert_eq!(dag[&1].value, "dar");
+        assert!(dag.get(&2).is_none());
+    }
+
+    #[test]
+    fn test_cycle() {
+        let mut dag = Dag::new();
+
+        dag.node(0, ());
+        dag.node(1, ());
+
+        dag.dependency(0, 1);
+        dag.dependency(1, 0);
+
+        let sorted = dag.sorted(fastrand::Rng::new());
+        let expected: &[&[i32]] = &[&[0, 1], &[1, 0]];
+
+        assert!(expected.contains(&sorted.as_slice()));
+    }
+
+    #[test]
+    fn test_diamond() {
+        let mut dag = Dag::new();
+
+        dag.node(0, ());
+        dag.node(1, ());
+        dag.node(2, ());
+        dag.node(3, ());
+
+        dag.dependency(1, 0);
+        dag.dependency(2, 0);
+        dag.dependency(3, 1);
+        dag.dependency(3, 2);
+
+        assert_eq!(dag.tips().map(|(k, _)| *k).collect::<Vec<_>>(), vec![3]);
+        assert_eq!(dag.roots().map(|(k, _)| *k).collect::<Vec<_>>(), vec![0]);
+
+        // All of the possible sort orders for the above graph.
+        let expected: &[&[i32]] = &[&[0, 1, 2, 3], &[0, 2, 1, 3]];
+        let actual = dag.sorted(fastrand::Rng::new());
+
+        assert!(expected.contains(&actual.as_slice()), "{:?}", actual);
+    }
+
+    #[test]
+    fn test_complex() {
+        let mut dag = Dag::new();
+
+        dag.node(0, ());
+        dag.node(1, ());
+        dag.node(2, ());
+        dag.node(3, ());
+        dag.node(4, ());
+        dag.node(5, ());
+
+        dag.dependency(3, 2);
+        dag.dependency(1, 3);
+        dag.dependency(2, 5);
+        dag.dependency(0, 5);
+        dag.dependency(0, 4);
+        dag.dependency(1, 4);
+
+        assert_eq!(
+            dag.tips().map(|(k, _)| *k).collect::<HashSet<_>>(),
+            HashSet::from_iter([1, 0])
+        );
+        assert_eq!(
+            dag.roots().map(|(k, _)| *k).collect::<HashSet<_>>(),
+            HashSet::from_iter([4, 5])
+        );
+
+        // All of the possible sort orders for the above graph.
+        let expected = &[
+            [4, 5, 0, 2, 3, 1],
+            [4, 5, 2, 0, 3, 1],
+            [4, 5, 2, 3, 0, 1],
+            [4, 5, 2, 3, 1, 0],
+            [5, 2, 3, 4, 0, 1],
+            [5, 2, 3, 4, 1, 0],
+            [5, 2, 4, 0, 3, 1],
+            [5, 2, 4, 3, 0, 1],
+            [5, 2, 4, 3, 1, 0],
+            [5, 4, 0, 2, 3, 1],
+            [5, 4, 2, 0, 3, 1],
+            [5, 4, 2, 3, 0, 1],
+            [5, 4, 2, 3, 1, 0],
+        ];
+        let rng = fastrand::Rng::new();
+        let mut sorts = HashSet::new();
+
+        while sorts.len() < expected.len() {
+            sorts.insert(dag.sorted(rng.clone()));
+        }
+        for e in expected {
+            assert!(sorts.remove(e.to_vec().as_slice()));
+        }
+        assert!(sorts.is_empty());
+    }
+}

--- a/radicle-dag/src/lib.rs
+++ b/radicle-dag/src/lib.rs
@@ -17,6 +17,16 @@ pub struct Node<K: Eq + Hash, V> {
     pub dependents: HashSet<K>,
 }
 
+impl<K: Eq + Hash, V> Node<K, V> {
+    fn new(value: V) -> Self {
+        Self {
+            value,
+            dependencies: HashSet::new(),
+            dependents: HashSet::new(),
+        }
+    }
+}
+
 impl<K: Eq + Hash, V> Borrow<V> for &Node<K, V> {
     fn borrow(&self) -> &V {
         &self.value
@@ -46,6 +56,14 @@ impl<K: Eq + Copy + Hash, V> Dag<K, V> {
             graph: HashMap::new(),
             tips: HashSet::new(),
             roots: HashSet::new(),
+        }
+    }
+
+    pub fn root(key: K, value: V) -> Self {
+        Self {
+            graph: HashMap::from_iter([(key, Node::new(value))]),
+            tips: HashSet::from_iter([key]),
+            roots: HashSet::from_iter([key]),
         }
     }
 


### PR DESCRIPTION
    Switch to our own DAG representation for COBs

    We're using petgraph to encode an operation based CRDT (each graph node
    is an operation) as a DAG, and one of the important things to ensure
    is that the final state is not influenced by the order of concurrent
    operations. In this case a concurrent operation would mean two potential
    graph traversal orders, as there's no direct edge between the two
    concurrent ops. This is essential a "partial order" of operations.

    To be able to test this, we'd want some kind of control over how
    neighbors are iterated over I guess, when there's more than one possible
    sort order. Say we have a graph like this:

```
                 ┌────────b◄─────┐
                 ▼               │
                 a               d
                 ▲               │
                 └────────c◄─────┘
```

    There are two possible topological traverse orders: [a, b, c, d] and [a,
    c, b, d]. Having a way to go through these different orders would
    be super handy.

    One option would be to allow random order traversal. This would allow us
    to test all orders by running the test enough times to likely test all
    permutations.

    Since petgraph doesn't support this, we implement our own simple DAG in
    `radicle-dag`, which implements random-order topological orders.

    For now, we don't make explicit use of these improvements, we simply
    replace the underlying graph with our own.