### PR TITLE
cli: Avoid trailing space in `patch list`

### DIFF
--- a/radicle-cli/src/commands/patch/list.rs
+++ b/radicle-cli/src/commands/patch/list.rs
@@ -39,7 +39,7 @@ pub fn run(
         }
     }
     term::blank();
-    term::print(term::format::badge_positive("YOU PROPOSED"));
+    term::print(term::format::badge_positive("YOU PROPOSED").trim_end());
 
     if own.is_empty() {
         term::blank();
@@ -52,7 +52,7 @@ pub fn run(
         }
     }
     term::blank();
-    term::print(term::format::badge_secondary("OTHERS PROPOSED"));
+    term::print(term::format::badge_secondary("OTHERS PROPOSED").trim_end());
 
     if other.is_empty() {
         term::blank();


### PR DESCRIPTION
Trailing spaces on terminal output provide no use.  As they are hard to see and difficult to handle, remove them from `patch list`.

An alternative is to make term::print() trim trailing spaces instead.  This is avoided because it violates the principle of least surprise.

Signed-off-by: Slack Coder <slackcoder@server.ky>