### PR TITLE
Fix install dependency errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "netservices"
 version = "0.1.0"
-source = "git+https://github.com/cyphernet-wg/rust-netservices#045ab140fd33ab3008a0ce8c86d8b9d01b08662c"
+source = "git+https://github.com/cyphernet-wg/rust-netservices?rev=045ab140fd33ab3008a0ce8c86d8b9d01b08662c#045ab140fd33ab3008a0ce8c86d8b9d01b08662c"
 dependencies = [
  "amplify",
  "cyphernet",
@@ -1918,7 +1918,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 [[package]]
 name = "poll-reactor"
 version = "0.1.0"
-source = "git+https://github.com/cyphernet-wg/rust-netservices#045ab140fd33ab3008a0ce8c86d8b9d01b08662c"
+source = "git+https://github.com/cyphernet-wg/rust-netservices?rev=045ab140fd33ab3008a0ce8c86d8b9d01b08662c#045ab140fd33ab3008a0ce8c86d8b9d01b08662c"
 dependencies = [
  "amplify",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ version = "0.1.0"
 
 [patch.crates-io.poll-reactor]
 git = "https://github.com/cyphernet-wg/rust-netservices"
-version = "0.1.0"
+rev = "045ab140fd33ab3008a0ce8c86d8b9d01b08662c"
 
 [patch.crates-io.netservices]
 git = "https://github.com/cyphernet-wg/rust-netservices"
-version = "0.1.0"
+rev = "045ab140fd33ab3008a0ce8c86d8b9d01b08662c"
 
 [patch.crates-io.radicle-git-ext]
 git = "https://github.com/radicle-dev/radicle-git"


### PR DESCRIPTION
Lock 'github.com/cyphernet-wg/rust-netservices' to a commit instead of version, as it introduced a breaking change. This will allow installing radicle-cli and radicle-remote-helper packages.

resolves  #193

edit: fixed ambiguity