### PR TITLE
Publish radicle-httpd binary for testing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,46 +23,6 @@ jobs:
       - name: Run tests
         run: cargo test --all --verbose --all-features
 
-  release-x86_64-linux-binaries:
-    needs: build
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-      - name: Configure build cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-x86_64-linux-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build the binaries
-        uses: addnab/docker-run-action@v3
-        with:
-          image: registry.gitlab.com/rust_musl_docker/image:stable-latest
-          options: -v ${{ github.workspace }}:/workdir -v /home/runner/.cargo/git:/root/.cargo/git -v /home/runner/.cargo/registry:/root/.cargo/registry
-          run: |
-            rustup target add x86_64-unknown-linux-musl
-            cd radicle-httpd
-            cargo build --release --target=x86_64-unknown-linux-musl
-            chmod --recursive go+r /root/.cargo/registry
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          workload_identity_provider: 'projects/281042598092/locations/global/workloadIdentityPools/github-actions/providers/google-cloud'
-          service_account: 'github-actions@radicle-services.iam.gserviceaccount.com'
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - id: 'upload-file'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: target/x86_64-unknown-linux-musl/release/radicle-httpd
-          destination: heartwood-artifacts/${{ github.sha }}/
-
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,6 +23,46 @@ jobs:
       - name: Run tests
         run: cargo test --all --verbose --all-features
 
+  release-x86_64-linux-binaries:
+    needs: build
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Configure build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-x86_64-linux-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build the binaries
+        uses: addnab/docker-run-action@v3
+        with:
+          image: registry.gitlab.com/rust_musl_docker/image:stable-latest
+          options: -v ${{ github.workspace }}:/workdir -v /home/runner/.cargo/git:/root/.cargo/git -v /home/runner/.cargo/registry:/root/.cargo/registry
+          run: |
+            rustup target add x86_64-unknown-linux-musl
+            cd radicle-httpd
+            cargo build --release --target=x86_64-unknown-linux-musl
+            chmod --recursive go+r /root/.cargo/registry
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/281042598092/locations/global/workloadIdentityPools/github-actions/providers/google-cloud'
+          service_account: 'github-actions@radicle-services.iam.gserviceaccount.com'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - id: 'upload-file'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: target/x86_64-unknown-linux-musl/release/radicle-httpd
+          destination: heartwood-artifacts/${{ github.sha }}/
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-testing.yml
+++ b/.github/workflows/frontend-testing.yml
@@ -1,0 +1,45 @@
+name: Upload binaries for frontend e2e tests
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  release-x86_64-linux-binaries:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Configure build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-x86_64-linux-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build the binaries
+        uses: addnab/docker-run-action@v3
+        with:
+          image: registry.gitlab.com/rust_musl_docker/image:stable-latest
+          options: -v ${{ github.workspace }}:/workdir -v /home/runner/.cargo/git:/root/.cargo/git -v /home/runner/.cargo/registry:/root/.cargo/registry
+          run: |
+            rustup target add x86_64-unknown-linux-musl
+            cd radicle-httpd
+            cargo build --release --target=x86_64-unknown-linux-musl
+            chmod --recursive go+r /root/.cargo/registry
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/281042598092/locations/global/workloadIdentityPools/github-actions/providers/google-cloud'
+          service_account: 'github-actions@radicle-services.iam.gserviceaccount.com'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - id: 'upload-file'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: target/x86_64-unknown-linux-musl/release/radicle-httpd
+          destination: heartwood-artifacts/${{ github.sha }}/


### PR DESCRIPTION
On a push to master, this job is going to upload `radicle-httpd` binary to a Google Cloud Storage bucket at a path `gs://heartwood-artifacts/<THIS_REPO_COMMIT_SHA>/radicle-httpd` that can subsequently be used in e2e tests [[1]] by simply downloading and executing it (since it’s statically linked).  e2e tests will check if `radicle-httpd` at the given `COMMIT_SHA` pass playwright tests.

[1]: https://github.com/radicle-dev/radicle-interface/blob/master/.github/workflows/check-e2e.yml