### PR TITLE
Test installing commands in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,6 +22,10 @@ jobs:
           RUSTFLAGS: -D warnings
       - name: Run tests
         run: cargo test --all --verbose --all-features
+      - name: Test Install
+        run: |
+          cargo install --path ./radicle-cli
+          cargo install --path ./radicle-remote-helper
 
   docs:
     name: Docs


### PR DESCRIPTION
For an unknown reason, `cargo test` may succeed when compiling `radicle-cli` and `radicle-remote-helper` packages for installation fail.

Add a test to prevent these errors from reaching the master branch.

resolves: #206