### PR TITLE
cli: alter use subcommands for patch

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,7 +21,18 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
       - name: Run tests
-        run: cargo test --all --verbose --all-features
+        run: |
+          cargo test --all --verbose --all-features
+
+          # Workaround for client document tests dependent on the remote
+          # helper. Tests which rely on these should be marked #[ignore] and
+          # whitelisted here.
+          #
+          # Marking them as 'ignored' will allow local testing to work as
+          # expected, yet allow these document tests to be covered during
+          # integration testing.
+          cargo install --locked --debug --path ./radicle-remote-helper
+          cargo test --all --verbose --all-features rad_patch -- --ignored
 
   docs:
     name: Docs

--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -1,0 +1,65 @@
+When contributing to another's project, it is common for the contribution to be
+of many commits and involve a discussion with the project's maintainer.  This is supported
+via Radicle's patches.
+
+Here we give a brief overview for using patches in our hypothetical car
+scenario.  It turns out instructions containing the power requirements were
+missing from the project.
+
+```
+$ git checkout -b flux-capacitor-power
+$ touch README.md
+```
+
+Here the instructions are added to the project's README for 1.21 gigawatts and
+commit the changes to git.
+
+```
+$ git add README.md
+$ git commit -m "Define power requirements"
+[flux-capacitor-power 7939a9e] Define power requirements
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ create mode 100644 README.md
+```
+
+Once the code is ready, we open (or create) a patch with our changes for the project.
+
+```
+$ rad patch open --message "define power requirements" --no-confirm
+
+🌱 Creating patch for heartwood
+
+ok Pushing HEAD to storage...
+ok Analyzing remotes...
+
+z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/master (cdf76ce) <- z6MknSL…StBU8Vi/flux-capacitor-power (7939a9e)
+1 commit(s) ahead, 0 commit(s) behind
+
+7939a9e Define power requirements
+
+
+╭─ define power requirements ───────
+
+No description provided.
+
+╰───────────────────────────────────
+
+
+ok Patch 3b1f58414e51266d7621203554a63eaee242b744 created 🌱
+```
+
+It will now be listed as one of the project's open patches.
+
+```
+$ rad patch
+
+ YOU PROPOSED
+
+define power requirements 3b1f58414e5 R0 7939a9e (flux-capacitor-power) ahead 1, behind 0
+└─ * opened by z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi (you) [..]
+
+ OTHERS PROPOSED
+
+Nothing to show.
+
+```

--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -16,8 +16,8 @@ commit the changes to git.
 
 ```
 $ git add README.md
-$ git commit -m "Define power requirements"
-[flux-capacitor-power 7939a9e] Define power requirements
+$ git commit -v -m "Define power requirements"
+[flux-capacitor-power 9dad201] Define power requirements
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 README.md
 ```
@@ -32,10 +32,10 @@ $ rad patch open --message "define power requirements" --no-confirm
 ok Pushing HEAD to storage...
 ok Analyzing remotes...
 
-z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/master (cdf76ce) <- z6MknSL…StBU8Vi/flux-capacitor-power (7939a9e)
+z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/master (cdf76ce) <- z6MknSL…StBU8Vi/flux-capacitor-power (9dad201)
 1 commit(s) ahead, 0 commit(s) behind
 
-7939a9e Define power requirements
+9dad201 Define power requirements
 
 
 ╭─ define power requirements ───────
@@ -45,7 +45,7 @@ No description provided.
 ╰───────────────────────────────────
 
 
-ok Patch 3b1f58414e51266d7621203554a63eaee242b744 created 🌱
+ok Patch b9bb418c6f504ee91e54c555bdc8fc37b4d9b28b created 🌱
 ```
 
 It will now be listed as one of the project's open patches.
@@ -55,7 +55,7 @@ $ rad patch
 
 - YOU PROPOSED -
 
-define power requirements 3b1f58414e5 R0 7939a9e (flux-capacitor-power) ahead 1, behind 0
+define power requirements b9bb418c6f5 R0 9dad201 (flux-capacitor-power) ahead 1, behind 0
 └─ * opened by z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi (you) [..]
 
 - OTHERS PROPOSED -

--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -53,12 +53,12 @@ It will now be listed as one of the project's open patches.
 ```
 $ rad patch
 
- YOU PROPOSED
+- YOU PROPOSED -
 
 define power requirements 3b1f58414e5 R0 7939a9e (flux-capacitor-power) ahead 1, behind 0
 └─ * opened by z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi (you) [..]
 
- OTHERS PROPOSED
+- OTHERS PROPOSED -
 
 Nothing to show.
 

--- a/radicle-cli/src/commands/patch/list.rs
+++ b/radicle-cli/src/commands/patch/list.rs
@@ -39,7 +39,10 @@ pub fn run(
         }
     }
     term::blank();
-    term::print(term::format::badge_positive("YOU PROPOSED"));
+    term::print(format!(
+        "-{}-",
+        term::format::badge_secondary("YOU PROPOSED")
+    ));
 
     if own.is_empty() {
         term::blank();
@@ -52,7 +55,10 @@ pub fn run(
         }
     }
     term::blank();
-    term::print(term::format::badge_secondary("OTHERS PROPOSED"));
+    term::print(format!(
+        "-{}-",
+        term::format::badge_secondary("OTHERS PROPOSED")
+    ));
 
     if other.is_empty() {
         term::blank();

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -22,9 +22,17 @@ fn test(
     };
 
     TestFormula::new()
-        .env("RAD_PASSPHRASE", "radicle")
-        .env("RAD_HOME", home.to_string_lossy())
+        .env("GIT_AUTHOR_DATE", "1671125284")
+        .env("GIT_AUTHOR_EMAIL", "radicle@localhost")
+        .env("GIT_AUTHOR_NAME", "radicle")
+        .env("GIT_COMMITTER_DATE", "1671125284")
+        .env("GIT_COMMITTER_EMAIL", "radicle@localhost")
+        .env("GIT_COMMITTER_NAME", "radicle")
         .env("RAD_DEBUG", "1")
+        .env("RAD_HOME", home.to_string_lossy())
+        .env("RAD_PASSPHRASE", "radicle")
+        .env("TZ", "Etc/GMT")
+        .env(radicle_cob::git::RAD_COMMIT_TIME, "1671125284")
         .cwd(cwd)
         .file(base.join(test))?
         .run()?;
@@ -93,10 +101,6 @@ fn rad_patch() {
 
     // Setup a test repository.
     fixtures::repository(working.path());
-    // Set a fixed commit time.
-    env::set_var(radicle_cob::git::RAD_COMMIT_TIME, "1671125284");
-    env::set_var("GIT_COMMITTER_DATE", "1671125284");
-    env::set_var("GIT_AUTHOR_DATE", "1671125284");
 
     test("examples/rad-init.md", working.path(), Some(&profile)).unwrap();
     test("examples/rad-issue.md", working.path(), Some(&profile)).unwrap();

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -94,6 +94,7 @@ fn rad_delegate() {
 }
 
 #[test]
+#[ignore]
 fn rad_patch() {
     let home = tempfile::tempdir().unwrap();
     let working = tempfile::tempdir().unwrap();

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -84,3 +84,21 @@ fn rad_delegate() {
     test("examples/rad-init.md", working.path(), Some(&profile)).unwrap();
     test("examples/rad-delegate.md", working.path(), Some(&profile)).unwrap();
 }
+
+#[test]
+fn rad_patch() {
+    let home = tempfile::tempdir().unwrap();
+    let working = tempfile::tempdir().unwrap();
+    let profile = profile(home.path());
+
+    // Setup a test repository.
+    fixtures::repository(working.path());
+    // Set a fixed commit time.
+    env::set_var(radicle_cob::git::RAD_COMMIT_TIME, "1671125284");
+    env::set_var("GIT_COMMITTER_DATE", "1671125284");
+    env::set_var("GIT_AUTHOR_DATE", "1671125284");
+
+    test("examples/rad-init.md", working.path(), Some(&profile)).unwrap();
+    test("examples/rad-issue.md", working.path(), Some(&profile)).unwrap();
+    test("examples/rad-patch.md", working.path(), Some(&profile)).unwrap();
+}


### PR DESCRIPTION
Make `rad patch` accept subcommands for specifying its operation in place of the '--command' notation.

For instance `rad patch update` versus `rad patch --update`.  Also make the default operation list active patches, replacing patch creation. Patch creation is now done via `rad patch open`.

Make these changes in a way consistent with other commands like `rad delegate`.

Add '--no-confirm' to patch to support this subcommand's documentation test.

References: #148 