### PR TITLE
github: Workaround test dep on git remote helper

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,7 +21,9 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
       - name: Run tests
-        run: cargo test --all --verbose --all-features
+        run: |
+          cargo install --locked --path ./radicle-remote-helper
+          cargo test --all --verbose --all-features
 
   docs:
     name: Docs


### PR DESCRIPTION
Workaround a client documentation test dependency on radicle's radicle-remote-helper.

The framework has yet to support using the projects version directly.  A proper fix is non-trivial.