### PR TITLE
node: Fix redundant announcements

### DIFF
--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -144,7 +144,7 @@ where
             info!("{}: Initializing: address = {}", self.name, self.ip);
 
             self.initialized = true;
-            self.service.initialize(LocalTime::now());
+            self.service.initialize(LocalTime::now()).unwrap();
         }
     }
 

--- a/radicle-node/src/wire/protocol.rs
+++ b/radicle-node/src/wire/protocol.rs
@@ -203,7 +203,9 @@ where
         proxy: net::SocketAddr,
         clock: LocalTime,
     ) -> Self {
-        service.initialize(clock);
+        service
+            .initialize(clock)
+            .expect("Wire::new: error initializing service");
 
         Self {
             service,


### PR DESCRIPTION
This change makes sure that nodes don't gossip announcements back to the announcers.

Since the tests were relying on this mechanism to populate the routing table, we had to change a few more things, such as adding the inventory to the node's routing table.

Signed-off-by: Alexis Sellier <self@cloudhead.io>