### PR TITLE
Add Op ID string formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "radicle-crypto",
  "serde",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/radicle-crdt/Cargo.toml
+++ b/radicle-crdt/Cargo.toml
@@ -11,6 +11,7 @@ fastrand = { version = "1.8.0", optional = true }
 num-traits = { version = "0.2.15", default-features = false, features = ["std"] }
 qcheck = { version = "1", optional = true }
 serde = { version = "1" }
+thiserror = { version = "1" }
 
 [dependencies.radicle-crypto]
 path = "../radicle-crypto"

--- a/radicle-crdt/src/clock.rs
+++ b/radicle-crdt/src/clock.rs
@@ -1,8 +1,11 @@
+use std::fmt;
+use std::str::FromStr;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use num_traits::Bounded;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::ord::Max;
 use crate::Semilattice as _;
@@ -45,11 +48,47 @@ impl Lamport {
     }
 }
 
+impl fmt::Display for Lamport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.get())
+    }
+}
+
 impl From<u64> for Lamport {
     fn from(counter: u64) -> Self {
         Self {
             counter: Max::from(counter),
         }
+    }
+}
+
+impl From<Lamport> for u64 {
+    fn from(arg: Lamport) -> Self {
+        arg.get()
+    }
+}
+
+/// Error decoding an operation from an entry.
+#[derive(Error, Debug)]
+pub enum LamportError {
+    #[error("invalid lamport clock value")]
+    Invalid,
+}
+
+impl FromStr for Lamport {
+    type Err = LamportError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
+
+impl TryFrom<&str> for Lamport {
+    type Error = LamportError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let v = s.parse::<u64>().map_err(|_| LamportError::Invalid)?;
+        Ok(v.into())
     }
 }
 


### PR DESCRIPTION
To help users, create an Op ID string format of the form '[cob::op::ActorId]/[cob::op::Lamport]'.

The formatting is not final and is intended to support development around interfacing with comments.

References: #245