### PR TITLE
radicle-httpd: Add `GET /api/v1/sessions/:id` route to get session information

### DIFF
--- a/radicle-httpd/Cargo.toml
+++ b/radicle-httpd/Cargo.toml
@@ -26,7 +26,7 @@ lexopt = { version = "0.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = { version = "1" }
-time = { version = "0.3.17" }
+time = { version = "0.3.17", features = ["parsing", "serde"] }
 tokio = { version = "1.21", default-features = false, features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.3.4", default-features = false, features = ["trace", "cors", "set-header"] }
 tracing = { version = "0.1.37", default-features = false, features = ["std", "log"] }

--- a/radicle-httpd/src/api.rs
+++ b/radicle-httpd/src/api.rs
@@ -33,7 +33,7 @@ type SessionId = String;
 #[derive(Clone)]
 pub struct Context {
     profile: Arc<Profile>,
-    sessions: Arc<RwLock<HashMap<SessionId, auth::AuthState>>>,
+    sessions: Arc<RwLock<HashMap<SessionId, auth::Session>>>,
 }
 
 impl Context {

--- a/radicle-httpd/src/api/auth.rs
+++ b/radicle-httpd/src/api/auth.rs
@@ -1,27 +1,21 @@
 use radicle::crypto::PublicKey;
-use serde::{Serialize, Serializer};
-use time::OffsetDateTime;
+use serde::{Deserialize, Serialize};
+use time::{serde::timestamp, OffsetDateTime};
 
-#[derive(Clone, PartialEq, PartialOrd)]
-pub struct DateTime(pub OffsetDateTime);
-
-impl Serialize for DateTime {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&format!("{}", self.0))
-    }
-}
-
-#[derive(Clone, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthState {
     Authorized,
     Unauthorized,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Session {
     pub status: AuthState,
     pub public_key: PublicKey,
-    pub issued_at: DateTime,
-    pub expires_at: DateTime,
+    #[serde(with = "timestamp")]
+    pub issued_at: OffsetDateTime,
+    #[serde(with = "timestamp")]
+    pub expires_at: OffsetDateTime,
 }

--- a/radicle-httpd/src/api/auth.rs
+++ b/radicle-httpd/src/api/auth.rs
@@ -11,25 +11,17 @@ impl Serialize for DateTime {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum AuthState {
-    Authorized(Session),
-    Unauthorized(Session),
+    Authorized,
+    Unauthorized,
 }
 
 #[derive(Clone)]
 pub struct Session {
-    pub status: String,
+    pub status: AuthState,
     pub public_key: PublicKey,
     pub issued_at: DateTime,
     pub expires_at: DateTime,
-}
-
-impl From<AuthState> for Session {
-    fn from(other: AuthState) -> Self {
-        match other {
-            AuthState::Authorized(s) => s,
-            AuthState::Unauthorized(s) => s,
-        }
-    }
 }

--- a/radicle-httpd/src/api/auth.rs
+++ b/radicle-httpd/src/api/auth.rs
@@ -11,6 +11,8 @@ impl Serialize for DateTime {
     }
 }
 
+#[derive(Clone, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum AuthState {
     Authorized(Session),
     Unauthorized {

--- a/radicle-httpd/src/api/auth.rs
+++ b/radicle-httpd/src/api/auth.rs
@@ -11,21 +11,25 @@ impl Serialize for DateTime {
     }
 }
 
-#[derive(Clone, Serialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Clone)]
 pub enum AuthState {
     Authorized(Session),
-    Unauthorized {
-        public_key: PublicKey,
-        expires_at: DateTime,
-    },
+    Unauthorized(Session),
 }
 
-// We copy the implementation of siwe::Message here to derive Serialization and Debug
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone)]
 pub struct Session {
+    pub status: String,
     pub public_key: PublicKey,
     pub issued_at: DateTime,
     pub expires_at: DateTime,
+}
+
+impl From<AuthState> for Session {
+    fn from(other: AuthState) -> Self {
+        match other {
+            AuthState::Authorized(s) => s,
+            AuthState::Unauthorized(s) => s,
+        }
+    }
 }

--- a/radicle-httpd/src/api/json.rs
+++ b/radicle-httpd/src/api/json.rs
@@ -14,6 +14,8 @@ use radicle_surf::blob::Blob;
 use radicle_surf::tree::Tree;
 use radicle_surf::{Commit, Stats};
 
+use crate::api::auth::Session;
+
 /// Returns JSON of a commit.
 pub(crate) fn commit(commit: &Commit) -> Value {
     json!({
@@ -29,6 +31,17 @@ pub(crate) fn commit(commit: &Commit) -> Value {
         "email": commit.committer.email,
         "time": commit.committer.time.seconds()
       }
+    })
+}
+
+/// Returns JSON of a session.
+pub(crate) fn session(session_id: String, session: &Session) -> Value {
+    json!({
+      "sessionId": session_id,
+      "status": session.status,
+      "publicKey": session.public_key,
+      "issuedAt": session.issued_at.unix_timestamp(),
+      "expiresAt": session.expires_at.unix_timestamp()
     })
 }
 

--- a/radicle-httpd/src/api/v1/sessions.rs
+++ b/radicle-httpd/src/api/v1/sessions.rs
@@ -7,12 +7,12 @@ use axum::{Json, Router};
 use hyper::StatusCode;
 use radicle::crypto::{PublicKey, Signature};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use time::{Duration, OffsetDateTime};
 
 use crate::api::auth::{AuthState, Session};
 use crate::api::axum_extra::Path;
 use crate::api::error::Error;
+use crate::api::json;
 use crate::api::Context;
 
 pub const UNAUTHORIZED_SESSIONS_EXPIRATION: Duration = Duration::seconds(60);
@@ -55,12 +55,7 @@ async fn session_create_handler(State(ctx): State<Context>) -> impl IntoResponse
 
     Ok::<_, Error>((
         StatusCode::CREATED,
-        Json(json!({
-            "sessionId": session_id,
-            "publicKey": session.public_key,
-            "issuedAt": session.issued_at,
-            "expiresAt": session.expires_at
-        })),
+        Json(json::session(session_id, &session)),
     ))
 }
 
@@ -73,12 +68,7 @@ async fn session_handler(
     let sessions = ctx.sessions.read().await;
     let session = sessions.get(&session_id).ok_or(Error::NotFound)?;
 
-    Ok::<_, Error>(Json(json!({
-        "status": session.status,
-        "publicKey": session.public_key,
-        "issuedAt": session.issued_at.unix_timestamp(),
-        "expiresAt": session.expires_at.unix_timestamp()
-    })))
+    Ok::<_, Error>(Json(json::session(session_id, session)))
 }
 
 /// Update session.


### PR DESCRIPTION
We currently don't have a way on for the web app to check the validity of a session_id, so we need a route to do that.

Also I didn't want to limit OK responses just to authorized sessions, but also return a OK response with the Unauthorized session information, which can become handy.