### PR TITLE
cli: Use localhost for rad web

### DIFF
--- a/radicle-cli/src/commands/web.rs
+++ b/radicle-cli/src/commands/web.rs
@@ -70,7 +70,7 @@ impl Args for Options {
             Options {
                 verbose,
                 host: host.unwrap_or(String::from("0.0.0.0:8080")),
-                web: web.unwrap_or(String::from("0.0.0.0:3000")),
+                web: web.unwrap_or(String::from("localhost:3000")),
             },
             vec![],
         ))


### PR DESCRIPTION
Since sessionStorage and localStorage use protocol + host + port as scope, we want to align this between the CLI and radicle-interface. Using localhost has other benefits as well, because browsers treat it differently when doing requests from the deployed app which is being served via https.