### PR TITLE
radicle-httpd: Add more issue endpoint tests

### DIFF
--- a/radicle-cli/examples/rad-issue.md
+++ b/radicle-cli/examples/rad-issue.md
@@ -11,7 +11,7 @@ The issue is now listed under our project.
 
 ```
 $ rad issue list
-de81d97d7fe07a80bfb339200c6af862d4526b6a "flux capacitor underpowered"
+5bce692884916d8d5f0c05824ce9ff44c04a82a8 "flux capacitor underpowered"
 ```
 
 Great! Now we've documented the issue for ourselves and others.
@@ -22,20 +22,20 @@ others to work on.  This is to ensure work is not duplicated.
 Let's assign ourselves to this one.
 
 ```
-$ rad assign de81d97d7fe07a80bfb339200c6af862d4526b6a z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad assign 5bce692884916d8d5f0c05824ce9ff44c04a82a8 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 It will now show in the list of issues assigned to us.
 
 ```
 $ rad issue list --assigned
-de81d97d7fe07a80bfb339200c6af862d4526b6a "flux capacitor underpowered" z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+5bce692884916d8d5f0c05824ce9ff44c04a82a8 "flux capacitor underpowered" z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Note: this can always be undone with the `unassign` subcommand.
 
 ```
-$ rad unassign de81d97d7fe07a80bfb339200c6af862d4526b6a z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad unassign 5bce692884916d8d5f0c05824ce9ff44c04a82a8 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Great, now we have communicated to the world about our car's defect.
@@ -44,8 +44,8 @@ But wait! We've found an important detail about the car's power requirements.
 It will help whoever works on a fix.
 
 ```
-$ rad comment de81d97d7fe07a80bfb339200c6af862d4526b6a --message 'The flux capacitor needs 1.21 Gigawatts'
+$ rad comment 5bce692884916d8d5f0c05824ce9ff44c04a82a8 --message 'The flux capacitor needs 1.21 Gigawatts'
 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6
-$ rad comment de81d97d7fe07a80bfb339200c6af862d4526b6a --reply-to z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6 --message 'More power!'
+$ rad comment 5bce692884916d8d5f0c05824ce9ff44c04a82a8 --reply-to z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6 --message 'More power!'
 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/7
 ```

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -38,6 +38,7 @@ fn test<'a>(
         .env("RAD_HOME", home.to_string_lossy())
         .env("RAD_PASSPHRASE", "radicle")
         .env("TZ", "UTC")
+        .env("LANG", "C")
         .env(radicle_cob::git::RAD_COMMIT_TIME, "1671125284")
         .envs(git::env::GIT_DEFAULT_CONFIG)
         .envs(envs)

--- a/radicle-httpd/src/api/auth.rs
+++ b/radicle-httpd/src/api/auth.rs
@@ -1,6 +1,10 @@
 use radicle::crypto::PublicKey;
 use serde::{Deserialize, Serialize};
-use time::{serde::timestamp, OffsetDateTime};
+use time::serde::timestamp;
+use time::{Duration, OffsetDateTime};
+
+pub const UNAUTHORIZED_SESSIONS_EXPIRATION: Duration = Duration::seconds(60);
+pub const AUTHORIZED_SESSIONS_EXPIRATION: Duration = Duration::weeks(1);
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]

--- a/radicle-httpd/src/api/json.rs
+++ b/radicle-httpd/src/api/json.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use radicle::cob::issue::{Issue, IssueId};
 use radicle::cob::patch::{Patch, PatchId};
 use radicle::cob::thread::{self, CommentId};
-use radicle::cob::Timestamp;
+use radicle::cob::{OpId, Timestamp};
 use radicle::identity::PublicKey;
 use radicle_surf::blob::Blob;
 use radicle_surf::tree::Tree;
@@ -129,6 +129,7 @@ struct Author {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Comment {
+    id: OpId,
     author: Author,
     body: String,
     reactions: [String; 0],
@@ -143,8 +144,9 @@ impl<'a> FromIterator<(&'a CommentId, &'a thread::Comment)> for Comments {
     fn from_iter<I: IntoIterator<Item = (&'a CommentId, &'a thread::Comment)>>(iter: I) -> Self {
         let mut comments = Vec::new();
 
-        for (_, comment) in iter {
+        for (id, comment) in iter {
             comments.push(Comment {
+                id: id.to_owned(),
                 author: Author {
                     id: comment.author(),
                 },

--- a/radicle/src/cob/thread.rs
+++ b/radicle/src/cob/thread.rs
@@ -133,6 +133,7 @@ impl PartialOrd for Comment {
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum Action {
     /// Comment on a thread.
+    #[serde(rename_all = "camelCase")]
     Comment {
         /// Comment body.
         body: String,


### PR DESCRIPTION
- Adds a `PATCH` method to `api::test` for e.g. updating issues.
- Adds endpoint tests for creating issues, creating a top-level comment, and replying to a comment.
- Also moves around some parts for better DX