### PR TITLE
rad:  Add comment `reply-to`

### DIFF
--- a/radicle-cli/examples/rad-issue.md
+++ b/radicle-cli/examples/rad-issue.md
@@ -45,4 +45,7 @@ It will help whoever works on a fix.
 
 ```
 $ rad comment de81d97d7fe07a80bfb339200c6af862d4526b6a --message 'The flux capacitor needs 1.21 Gigawatts'
+z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6
+$ rad comment de81d97d7fe07a80bfb339200c6af862d4526b6a --reply-to z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6 --message 'More power!'
+z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/7
 ```

--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -112,4 +112,7 @@ And lets leave a quick comment for our team:
 
 ```
 $ rad comment 15141cf1497627e2db54362972dd9533f62d1dcb --message 'I cannot wait to get back to the 90s!'
+z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/5
+$ rad comment 15141cf1497627e2db54362972dd9533f62d1dcb --message 'I cannot wait to get back to the 90s!' --reply-to z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/5
+z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6
 ```


### PR DESCRIPTION
Allow replying to patch and issue comments using `rad comment --reply-to` option.

references #187