### PR TITLE
node: Move to NoiseXK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "amplify"
-version = "4.0.0-beta.7"
+version = "4.0.0-beta.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc8da6203c5311cc0d74155341a5577564b8360976988eeb5ce7ab6903757f1"
+checksum = "72eaf6c304959bf74ba94973ebea642729f583000ef77e7139844642cc066004"
 dependencies = [
  "amplify_derive",
  "amplify_num",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "amplify_derive"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a258501c851f9dec1549e046d551b645b8b970e30aca85dbec2d6e36cda8e91"
+checksum = "01c4835e964725149d7961ec5af2ca1302f6f68c8c738b4acb06185f596c3333"
 dependencies = [
  "amplify_syn",
  "proc-macro2",
@@ -55,15 +55,15 @@ dependencies = [
 
 [[package]]
 name = "amplify_num"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27d3d00d3d115395a7a8a4dc045feb7aa82b641e485f7e15f4e67ac16f4f56d"
+checksum = "ddce3bc63e807ea02065e8d8b702695f3d302ae4158baddff8b0ce5c73947251"
 
 [[package]]
 name = "amplify_syn"
-version = "1.1.6"
+version = "2.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da24db1445cc7bc3842fa072c2d51fe5b25b812b6a572d65842a4c72e87221ac"
+checksum = "2e3db5cb96f8f18a9566a975c521b77485f6f8e3e8d866d0f52369446ba31274"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "cypheraddr"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe21bd66fbbd74b706a551b0f56d8ee2488300f5a7cff41febce5973fa05cbc7"
+checksum = "41a05c461a9b86ba80542a5204924fd3cae3f47be011e00b1bbef9d71d95b3bb"
 dependencies = [
  "amplify",
  "base32",
@@ -583,21 +583,21 @@ dependencies = [
 
 [[package]]
 name = "cyphergraphy"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b94c89b484ddb937306c3ae8122b866749d1d47768b5c4a1e3e8e72ea8270"
+checksum = "3c8e45921460ef188da680742fd641f9b2a85d0de6bce12ce26e64c0f4913b41"
 dependencies = [
  "amplify",
- "ed25519-compact",
+ "ec25519",
  "multibase",
  "sha2 0.10.6",
 ]
 
 [[package]]
 name = "cyphernet"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c479a27a1c33fe0a146b6e7048fd373f48ed11205bb6c956d05d090fe749d2fe"
+checksum = "5c4cd4c5d6937b81f3df6bb26fe94b4d1c52dd2cfd85507d063d9892cd64448d"
 dependencies = [
  "cypheraddr",
  "cyphergraphy",
@@ -683,6 +683,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ec25519"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfd533a2fc01178c738c99412ae1f7e1ad2cb37c2e14bfd87e9d4618171c825"
+dependencies = [
+ "ct-codecs",
+ "ed25519",
+ "getrandom 0.2.8",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,17 +715,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-compact"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
-dependencies = [
- "ct-codecs",
- "ed25519",
- "getrandom 0.2.8",
-]
-
-[[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "eidolon-auth"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d8d05034e0462d2df39fbbd8dbf24b0c0c4337541850ec17ace0b6b42d787"
+checksum = "4a764411b1ee8bcacb5203d24e9f0b2d192be62b23ea1c16d0e3462e103f3ffc"
 dependencies = [
  "amplify",
  "cyphergraphy",
@@ -1435,13 +1435,12 @@ dependencies = [
 
 [[package]]
 name = "netservices"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c55aa6eb316df39bd0d90c845bd02bc0c10629788aae523a8759c6d3632d568"
+checksum = "dc700700b1a95cd1eafc4c25c48ac42f72a54ab8c5fa809eef630bebbb390312"
 dependencies = [
  "amplify",
  "cyphernet",
- "ed25519-compact",
  "io-reactor",
  "libc",
  "rand 0.8.5",
@@ -1450,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "noise-framework"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce256b1337e403d6576c5af917a2152441e94d430bb3202e13b7f952fa53e49"
+checksum = "daedd5a3c07ef713cb9c4b6f263837822d70412517576dcacd050fa0d1ba99bd"
 dependencies = [
  "amplify",
  "chacha20poly1305",
@@ -1883,7 +1882,6 @@ dependencies = [
 name = "radicle-cob"
 version = "0.1.0"
 dependencies = [
- "ed25519-compact",
  "fastrand",
  "git-commit",
  "git-ref-format",
@@ -1923,7 +1921,7 @@ dependencies = [
  "amplify",
  "base64",
  "cyphernet",
- "ed25519-compact",
+ "ec25519",
  "fastrand",
  "git-ref-format",
  "multibase",
@@ -2491,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "socks5-client"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80f67376257f749cbf2835799705650d76833389e80dabd2986082fb2f42072"
+checksum = "4091196d57cf9436ebecbec4c572b2be61373a7aaa632a3e93a5cb8555ec1b79"
 dependencies = [
  "amplify",
  "cypheraddr",

--- a/radicle-cob/Cargo.toml
+++ b/radicle-cob/Cargo.toml
@@ -42,7 +42,6 @@ version = "1.0"
 features = ["derive"]
 
 [dev-dependencies]
-ed25519-compact = { version = "2.0.2", features = ["pem"] }
 fastrand = { version = "1.8.0", default-features = false }
 git-ref-format = { version = "0.2", features = ["macro"] }
 tempfile = { version = "3" }

--- a/radicle-crypto/Cargo.toml
+++ b/radicle-crypto/Cargo.toml
@@ -14,9 +14,9 @@ ssh = ["base64", "radicle-ssh", "ssh-key"]
 
 [dependencies]
 amplify = { version = "4.0.0-beta.4" }
-ed25519-compact = { version = "2.0.2", features = ["pem"] }
-cyphernet = { version = "0.1.0", optional = true }
+cyphernet = { version = "0.2.0", optional = true }
 multibase = { version = "0.9.1" }
+ec25519 = { version = "0.1.0", features = [] }
 serde = { version = "1", features = ["derive"] }
 sha2 = { version = "0.10.2" }
 sqlite = { version = "0.30.3", optional = true }

--- a/radicle-crypto/src/test/signer.rs
+++ b/radicle-crypto/src/test/signer.rs
@@ -76,23 +76,27 @@ impl Signer for MockSigner {
 impl cyphernet::EcSk for MockSigner {
     type Pk = PublicKey;
 
+    // TODO: Should be renamed to 'generate'.
     fn generate_keypair() -> (Self, Self::Pk)
     where
         Self: Sized,
     {
-        unimplemented! {}
+        let kp = Self::default();
+        let pk = kp.pk;
+
+        (kp, pk)
     }
 
     fn to_pk(&self) -> Result<Self::Pk, cyphernet::EcSkInvalid> {
-        Ok(*self.public_key())
+        Ok(self.pk)
     }
 }
 
 #[cfg(feature = "cyphernet")]
-impl cyphernet::EcSign for MockSigner {
-    type Sig = Signature;
+impl cyphernet::Ecdh for MockSigner {
+    type SharedSecret = [u8; 32];
 
-    fn sign(&self, msg: impl AsRef<[u8]>) -> Self::Sig {
-        Signer::sign(self, msg.as_ref())
+    fn ecdh(&self, pk: &Self::Pk) -> Result<Self::SharedSecret, cyphernet::EcdhError> {
+        self.sk.ecdh(pk).map_err(|_| cyphernet::EcdhError::WeakPk)
     }
 }

--- a/radicle-node/Cargo.toml
+++ b/radicle-node/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = { version = "1" }
 chrono = { version = "0.4.0" }
 colored = { version = "1.9.0" }
 crossbeam-channel = { version = "0.5.6" }
-cyphernet = { version = "0.1.0", features = ["tor", "dns", "ed25519", "p2p-ed25519"] }
+cyphernet = { version = "0.2.0", features = ["tor", "dns", "ed25519", "p2p-ed25519"] }
 fastrand = { version = "1.8.0" }
 git-ref-format = { version = "0.2", features = ["serde", "macro"] }
 io-reactor = { version = "0.1.0", features = ["popol"] }
@@ -24,7 +24,7 @@ lexopt = { version = "0.2.1" }
 libc = { version = "0.2.137" }
 log = { version = "0.4.17", features = ["std"] }
 localtime = { version = "1.1.0" }
-netservices = { version = "0.1.0", features = ["io-reactor", "socket2"] }
+netservices = { version = "0.2.0", features = ["io-reactor", "socket2"] }
 nonempty = { version = "0.8.1", features = ["serialize"] }
 qcheck = { version = "1", default-features = false, optional = true }
 sqlite = { version = "0.30.3" }

--- a/radicle-node/src/runtime/handle.rs
+++ b/radicle-node/src/runtime/handle.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crossbeam_channel as chan;
-use cyphernet::EcSign;
+use cyphernet::Ecdh;
 use thiserror::Error;
 
 use crate::crypto::Signer;
@@ -56,7 +56,7 @@ impl<T> From<chan::SendError<T>> for Error {
     }
 }
 
-pub struct Handle<G: Signer + EcSign> {
+pub struct Handle<G: Signer + Ecdh> {
     pub(crate) home: Home,
     pub(crate) controller: reactor::Controller<wire::Control<G>>,
 
@@ -64,13 +64,13 @@ pub struct Handle<G: Signer + EcSign> {
     shutdown: Arc<AtomicBool>,
 }
 
-impl<G: Signer + EcSign> fmt::Debug for Handle<G> {
+impl<G: Signer + Ecdh> fmt::Debug for Handle<G> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Handle").field("home", &self.home).finish()
     }
 }
 
-impl<G: Signer + EcSign> Clone for Handle<G> {
+impl<G: Signer + Ecdh> Clone for Handle<G> {
     fn clone(&self) -> Self {
         Self {
             home: self.home.clone(),
@@ -80,7 +80,7 @@ impl<G: Signer + EcSign> Clone for Handle<G> {
     }
 }
 
-impl<G: Signer + EcSign + 'static> Handle<G> {
+impl<G: Signer + Ecdh + 'static> Handle<G> {
     pub fn new(home: Home, controller: reactor::Controller<wire::Control<G>>) -> Self {
         Self {
             home,
@@ -104,7 +104,7 @@ impl<G: Signer + EcSign + 'static> Handle<G> {
     }
 }
 
-impl<G: Signer + EcSign + 'static> radicle::node::Handle for Handle<G> {
+impl<G: Signer + Ecdh + 'static> radicle::node::Handle for Handle<G> {
     type Sessions = Sessions;
     type Error = Error;
     type FetchResult = FetchResult;

--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -953,7 +953,7 @@ where
 
                 return Err(session::Error::Misbehavior);
             }
-            (session::State::Connected { initialized, .. }, Message::Initialize {}) => {
+            (session::State::Connected { initialized, .. }, Message::Initialize { .. }) => {
                 // Already initialized!
                 if *initialized {
                     debug!(
@@ -1537,7 +1537,7 @@ mod gossip {
         };
 
         let mut msgs = vec![
-            Message::init(),
+            Message::init(*signer.public_key()),
             Message::inventory(gossip::inventory(now, inventory), signer),
             Message::subscribe(
                 filter,

--- a/radicle-node/src/service/message.rs
+++ b/radicle-node/src/service/message.rs
@@ -304,7 +304,7 @@ impl Announcement {
 #[derive(Clone, PartialEq, Eq)]
 pub enum Message {
     /// The first message sent to a peer after connection.
-    Initialize {},
+    Initialize { node_id: NodeId },
 
     /// Subscribe to gossip messages matching the filter and time range.
     Subscribe(Subscribe),
@@ -333,8 +333,8 @@ pub enum Message {
 }
 
 impl Message {
-    pub fn init() -> Self {
-        Self::Initialize {}
+    pub fn init(node_id: NodeId) -> Self {
+        Self::Initialize { node_id }
     }
 
     pub fn announcement(

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -243,7 +243,7 @@ where
 
         self.initialize();
         self.service.connected(remote_id, Link::Inbound);
-        self.receive(remote_id, Message::init());
+        self.receive(remote_id, Message::init(remote_id));
 
         let mut msgs = self.messages(remote_id);
         msgs.find(|m| matches!(m, Message::Initialize { .. }))
@@ -282,7 +282,7 @@ where
         })
         .expect("`inventory-announcement` must be sent");
 
-        self.receive(remote_id, Message::init());
+        self.receive(remote_id, Message::init(remote_id));
     }
 
     pub fn elapse(&mut self, duration: LocalDuration) {

--- a/radicle-node/src/wire/message.rs
+++ b/radicle-node/src/wire/message.rs
@@ -194,7 +194,9 @@ impl wire::Encode for Message {
         let mut n = self.type_id().encode(writer)?;
 
         match self {
-            Self::Initialize {} => {}
+            Self::Initialize { node_id } => {
+                n += node_id.encode(writer)?;
+            }
             Self::Subscribe(Subscribe {
                 filter,
                 since,
@@ -243,7 +245,11 @@ impl wire::Decode for Message {
         let type_id = reader.read_u16::<NetworkEndian>()?;
 
         match MessageType::try_from(type_id) {
-            Ok(MessageType::Initialize) => Ok(Self::Initialize {}),
+            Ok(MessageType::Initialize) => {
+                let node_id = NodeId::decode(reader)?;
+
+                Ok(Self::Initialize { node_id })
+            }
             Ok(MessageType::Subscribe) => {
                 let filter = Filter::decode(reader)?;
                 let since = Timestamp::decode(reader)?;

--- a/radicle-node/src/worker.rs
+++ b/radicle-node/src/worker.rs
@@ -3,7 +3,7 @@ use std::thread::JoinHandle;
 use std::{env, io, net, process, thread, time};
 
 use crossbeam_channel as chan;
-use cyphernet::EcSign;
+use cyphernet::Ecdh;
 use netservices::tunnel::Tunnel;
 use netservices::{NetSession, SplitIo};
 
@@ -58,21 +58,21 @@ impl FetchError {
 
 /// Task to be accomplished on a worker thread.
 /// This is either going to be an outgoing or incoming fetch.
-pub struct Task<G: Signer + EcSign> {
+pub struct Task<G: Signer + Ecdh> {
     pub fetch: Fetch,
     pub session: WireSession<G>,
     pub drain: Vec<u8>,
 }
 
 /// Worker response.
-pub struct TaskResult<G: Signer + EcSign> {
+pub struct TaskResult<G: Signer + Ecdh> {
     pub fetch: Fetch,
     pub result: Result<Vec<RefUpdate>, FetchError>,
     pub session: WireSession<G>,
 }
 
 /// A worker that replicates git objects.
-struct Worker<G: Signer + EcSign> {
+struct Worker<G: Signer + Ecdh> {
     storage: Storage,
     tasks: chan::Receiver<Task<G>>,
     daemon: net::SocketAddr,
@@ -82,7 +82,7 @@ struct Worker<G: Signer + EcSign> {
     name: String,
 }
 
-impl<G: Signer + EcSign + 'static> Worker<G> {
+impl<G: Signer + Ecdh + 'static> Worker<G> {
     /// Waits for tasks and runs them. Blocks indefinitely unless there is an error receiving
     /// the next task.
     fn run(mut self) -> Result<(), chan::RecvError> {
@@ -303,7 +303,7 @@ pub struct Pool {
 
 impl Pool {
     /// Create a new worker pool with the given parameters.
-    pub fn with<G: Signer + EcSign + 'static>(
+    pub fn with<G: Signer + Ecdh + 'static>(
         tasks: chan::Receiver<Task<G>>,
         handle: Handle<G>,
         config: Config,

--- a/radicle/Cargo.toml
+++ b/radicle/Cargo.toml
@@ -13,8 +13,7 @@ sql = ["sqlite"]
 [dependencies]
 amplify = { version = "4.0.0-beta.7", default-features = false, features = ["std"] }
 crossbeam-channel = { version = "0.5.6" }
-# FIXME: Remove the extra cyphernet features once we're able to.
-cyphernet = { version = "0.1.0", features = ["tor", "dns", "i2p", "nym", "ed25519"] }
+cyphernet = { version = "0.2.0", features = ["tor", "dns", "ed25519"] }
 fastrand = { version = "1.8.0" }
 git-ref-format = { version = "0", features = ["serde", "macro"] }
 multibase = { version = "0.9.1" }


### PR DESCRIPTION
Move from NoiseNN with a custom authentication protocol, to NoiseXK.
Uses ECDH on the ed25519 curve via the `ec25519` library.