### PR TITLE
radicle-httpd: Add `assignees` to Issues::create

### DIFF
--- a/radicle-cli/examples/rad-issue.md
+++ b/radicle-cli/examples/rad-issue.md
@@ -11,7 +11,7 @@ The issue is now listed under our project.
 
 ```
 $ rad issue list
-17e52fd6b2cd2e0f9317e18371dc978a691ed1e3 "flux capacitor underpowered"
+2b4650e3c66d568132034de0d02871a2fbf9c5b5 "flux capacitor underpowered"
 ```
 
 Great! Now we've documented the issue for ourselves and others.
@@ -22,20 +22,20 @@ others to work on.  This is to ensure work is not duplicated.
 Let's assign ourselves to this one.
 
 ```
-$ rad assign 17e52fd6b2cd2e0f9317e18371dc978a691ed1e3 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad assign 2b4650e3c66d568132034de0d02871a2fbf9c5b5 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 It will now show in the list of issues assigned to us.
 
 ```
 $ rad issue list --assigned
-17e52fd6b2cd2e0f9317e18371dc978a691ed1e3 "flux capacitor underpowered" z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+2b4650e3c66d568132034de0d02871a2fbf9c5b5 "flux capacitor underpowered" z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Note: this can always be undone with the `unassign` subcommand.
 
 ```
-$ rad unassign 17e52fd6b2cd2e0f9317e18371dc978a691ed1e3 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad unassign 2b4650e3c66d568132034de0d02871a2fbf9c5b5 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Great, now we have communicated to the world about our car's defect.
@@ -44,8 +44,8 @@ But wait! We've found an important detail about the car's power requirements.
 It will help whoever works on a fix.
 
 ```
-$ rad comment 17e52fd6b2cd2e0f9317e18371dc978a691ed1e3 --message 'The flux capacitor needs 1.21 Gigawatts'
-z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6
-$ rad comment 17e52fd6b2cd2e0f9317e18371dc978a691ed1e3 --reply-to z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6 --message 'More power!'
+$ rad comment 2b4650e3c66d568132034de0d02871a2fbf9c5b5 --message 'The flux capacitor needs 1.21 Gigawatts'
 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/7
+$ rad comment 2b4650e3c66d568132034de0d02871a2fbf9c5b5 --reply-to z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/7 --message 'More power!'
+z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/8
 ```

--- a/radicle-cli/src/commands/issue.rs
+++ b/radicle-cli/src/commands/issue.rs
@@ -38,6 +38,7 @@ Options
 pub struct Metadata {
     title: String,
     labels: Vec<Tag>,
+    assignees: Vec<cob::ActorId>,
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -205,7 +206,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
             title: Some(title),
             description: Some(description),
         } => {
-            issues.create(title, description, &[], &signer)?;
+            issues.create(title, description, &[], &[], &signer)?;
         }
         Operation::Show { id } => {
             let issue = issues
@@ -227,6 +228,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
             let meta = Metadata {
                 title: title.unwrap_or("Enter a title".to_owned()),
                 labels: vec![],
+                assignees: vec![],
             };
             let yaml = serde_yaml::to_string(&meta)?;
             let doc = format!(
@@ -263,6 +265,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                     &meta.title,
                     description.trim(),
                     meta.labels.as_slice(),
+                    meta.assignees.as_slice(),
                     &signer,
                 )?;
             }

--- a/radicle-httpd/src/api/test.rs
+++ b/radicle-httpd/src/api/test.rs
@@ -23,7 +23,7 @@ use crate::api::{auth, Context};
 pub const HEAD: &str = "1e978d19f251cd9821d9d9a76d1bd436bf0690d5";
 pub const HEAD_1: &str = "f604ce9fd5b7cc77b7609beda45ea8760bee78f7";
 pub const PATCH_ID: &str = "4250f0117659ee4de9af99e699a63395cd6ffa1c";
-pub const ISSUE_ID: &str = "d8131af9738258fac139c4c96b71c02411f94892";
+pub const ISSUE_ID: &str = "8adca8aad2a2cb99b9847d20193930cde2042a57";
 
 const PASSWORD: &str = "radicle";
 
@@ -112,6 +112,7 @@ pub fn seed(dir: &Path) -> Context {
         .create(
             "Issue #1".to_string(),
             "Change 'hello world' to 'hello everyone'".to_string(),
+            &[],
             &[],
             &signer,
         )

--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -14,7 +14,7 @@ use tower_http::set_header::SetResponseHeaderLayer;
 
 use radicle::cob::issue::{Action, Issues};
 use radicle::cob::patch::Patches;
-use radicle::cob::{thread, Tag};
+use radicle::cob::{thread, ActorId, Tag};
 use radicle::identity::Id;
 use radicle::node::NodeId;
 use radicle::storage::{git::paths, ReadRepository, WriteStorage};
@@ -404,6 +404,7 @@ pub struct IssueCreate {
     pub title: String,
     pub description: String,
     pub tags: Vec<Tag>,
+    pub assignees: Vec<ActorId>,
 }
 
 /// Create a new issue.
@@ -424,7 +425,13 @@ async fn issue_create_handler(
     let repo = storage.repository(project)?;
     let mut issues = Issues::open(ctx.profile.public_key, &repo)?;
     let issue = issues
-        .create(issue.title, issue.description, &issue.tags, &signer)
+        .create(
+            issue.title,
+            issue.description,
+            &issue.tags,
+            &issue.assignees,
+            &signer,
+        )
         .map_err(Error::from)?;
 
     Ok::<_, Error>((
@@ -551,7 +558,7 @@ mod routes {
 
     use crate::api::test::{self, get, patch, post, HEAD, HEAD_1, ISSUE_ID, PATCH_ID};
 
-    const CREATED_ISSUE_ID: &str = "768c6735912a34856552ae6a9ca77d728962bf31";
+    const CREATED_ISSUE_ID: &str = "b56febfba1e7dd20f4aea43ca2fe9dcf1fd448ba";
 
     #[tokio::test]
     async fn test_projects_root() {
@@ -1041,6 +1048,7 @@ mod routes {
             "title": "Issue #2",
             "description": "Change 'hello world' to 'hello everyone'",
             "tags": ["bug"],
+            "assignees": [],
         }))
         .unwrap();
         let response = post(
@@ -1147,7 +1155,7 @@ mod routes {
                   "replyTo": null,
                 },
                 {
-                  "id": "z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/4",
+                  "id": "z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/5",
                   "author": {
                       "id": "z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi",
                   },
@@ -1217,7 +1225,7 @@ mod routes {
                   "replyTo": null,
                 },
                 {
-                  "id": "z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/4",
+                  "id": "z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/5",
                   "author": {
                       "id": "z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi",
                   },


### PR DESCRIPTION
We currently don't allow to pass assignees during the issue creation.

This PR allows the passing of a vector of ActorIds during issue creation by the httpd or the cli
Also modifies some tests to check that the issue creation, handles tags and assignees accordingly