### PR TITLE
radicle: sign blob hash instead of content

### DIFF
--- a/radicle/src/identity/doc.rs
+++ b/radicle/src/identity/doc.rs
@@ -208,8 +208,8 @@ impl Doc<Verified> {
     }
 
     pub fn sign<G: crypto::Signer>(&self, signer: &G) -> Result<(git::Oid, Signature), DocError> {
-        let (oid, bytes) = self.encode()?;
-        let sig = signer.sign(&bytes);
+        let (oid, _) = self.encode()?;
+        let sig = signer.sign(oid.as_bytes());
 
         Ok((oid, sig))
     }
@@ -224,7 +224,7 @@ impl Doc<Verified> {
         let sigs = trailers::parse_signatures(msg)?;
 
         for (pk, sig) in &sigs {
-            if let Err(err) = pk.verify(blob.content(), sig) {
+            if let Err(err) = pk.verify(blob.id().as_bytes(), sig) {
                 return Err(DocError::Signature(*pk, err));
             }
         }

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -245,7 +245,7 @@ impl Repository {
         let oid = Doc::init(
             doc.as_slice(),
             remote,
-            &[(signer.public_key(), signer.sign(&doc))],
+            &[(signer.public_key(), signer.sign(doc_oid.as_bytes()))],
             repo.raw(),
         )?;
 


### PR DESCRIPTION
Fixes #291 

The signatures for Radicle identities were using the documents content.

It is standard to use the hash of the content instead, since signing and verification is faster on a smaller set of data.

Use the resulting Git blob's object id, i.e. `git hash-object`, as the signing and verifying payload.
