### PR TITLE
radicle-httpd: Add delegates to project routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ dependencies = [
  "flate2",
  "hyper",
  "lexopt",
+ "nonempty 0.8.1",
  "radicle",
  "radicle-cli",
  "radicle-crypto",

--- a/radicle-httpd/Cargo.toml
+++ b/radicle-httpd/Cargo.toml
@@ -25,6 +25,7 @@ flate2 = { version = "1" }
 hyper = { version = "0.14.17", default-features = false }
 lexopt = { version = "0.2.1" }
 radicle-surf = { version = "0.9.0", default-features = false, features = ["serde"] }
+nonempty = { version = "0.8.1", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = { version = "1" }

--- a/radicle-httpd/src/api/error.rs
+++ b/radicle-httpd/src/api/error.rs
@@ -42,6 +42,10 @@ pub enum Error {
     #[error(transparent)]
     GitProject(#[from] radicle::storage::git::ProjectError),
 
+    /// Project doc error.
+    #[error(transparent)]
+    ProjectDoc(#[from] radicle::identity::doc::PayloadError),
+
     /// Surf directory error.
     #[error(transparent)]
     SurfDir(#[from] radicle_surf::fs::error::Directory),

--- a/radicle-httpd/src/api/v1/delegates.rs
+++ b/radicle-httpd/src/api/v1/delegates.rs
@@ -42,7 +42,8 @@ async fn delegates_projects_handler(
             let Ok(doc) = repo.identity_of(ctx.profile.id()) else { return None };
             let Ok(payload) = doc.project() else { return None };
 
-            if !doc.delegates.iter().any(|d| *d == delegate) {
+            let delegates = doc.delegates;
+            if !delegates.iter().any(|d| *d == delegate) {
                 return None;
             }
 
@@ -51,6 +52,7 @@ async fn delegates_projects_handler(
 
             Some(Info {
                 payload,
+                delegates,
                 head,
                 issues,
                 patches: 0,
@@ -89,6 +91,7 @@ mod routes {
                 "name": "hello-world",
                 "description": "Rad repository for tests",
                 "defaultBranch": "master",
+                "delegates": ["did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi"],
                 "head": HEAD,
                 "patches": 0,
                 "issues": 1,

--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -78,11 +78,14 @@ async fn project_root_handler(
             let Ok(repo) = storage.repository(id) else { return None };
             let Ok((_, head)) = repo.head() else { return None };
             let Ok(payload) = repo.project_of(ctx.profile.id()) else { return None };
+            let Ok(doc) = repo.identity_of(ctx.profile.id()) else { return None };
             let Ok(issues) = Issues::open(ctx.profile.public_key, &repo) else { return None };
             let Ok(issues) = (*issues).count() else { return None };
+            let delegates = doc.delegates;
 
             Some(Info {
                 payload,
+                delegates,
                 head,
                 issues,
                 patches: 0,
@@ -574,6 +577,7 @@ mod routes {
                 "name": "hello-world",
                 "description": "Rad repository for tests",
                 "defaultBranch": "master",
+                "delegates": ["did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi"],
                 "head": HEAD,
                 "patches": 0,
                 "issues": 1,
@@ -596,6 +600,7 @@ mod routes {
                "name": "hello-world",
                "description": "Rad repository for tests",
                "defaultBranch": "master",
+               "delegates": ["did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi"],
                "head": HEAD,
                "patches": 0,
                "issues": 1,


### PR DESCRIPTION
This PR adds the delegates available to a remote to the project route.

```diff
http://0.0.0.0:8080/api/v1/projects/rad:z2wBFUvWarjNbKBuDJ7CBTxeg8dqg

{
    "name": "issue-test-repo",
    "description": "TBD",
    "defaultBranch": "master",
+   "delegates": [
+     "did:key:z6Mkv3pqBci7JY2uChMWhtVhVKcNfr84ZidpZekdRF6MkF3E"
+   ],
    "head": "daafeb8ac3650b98fd12492bac0f7d5ef64f8c80",
    "patches": 0,
    "issues": 5,
    "id": "rad:z2wBFUvWarjNbKBuDJ7CBTxeg8dqg"
}
```

```diff
http://0.0.0.0:8080/api/v1/projects
[
  {
      "name": "issue-test-repo",
      "description": "TBD",
      "defaultBranch": "master",
+     "delegates": [
+       "did:key:z6Mkv3pqBci7JY2uChMWhtVhVKcNfr84ZidpZekdRF6MkF3E"
+     ],
      "head": "daafeb8ac3650b98fd12492bac0f7d5ef64f8c80",
      "patches": 0,
      "issues": 5,
      "id": "rad:z2wBFUvWarjNbKBuDJ7CBTxeg8dqg"
  }
]
```