### PR TITLE
cli: add missing patch commands

### DIFF
--- a/radicle-cli/src/commands/patch.rs
+++ b/radicle-cli/src/commands/patch.rs
@@ -28,6 +28,8 @@ pub const HELP: Help = Help {
 Usage
 
     rad patch
+    rad patch list
+    rad patch show <id>
     rad patch open [<option>...]
     rad patch update <id> [<option>...]
 


### PR DESCRIPTION
The `list` and `show` commands were missing from the HELP message.

Add them to the HELP message.