### PR TITLE
Add possibility to checkout a patch 

### DIFF
--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -117,3 +117,11 @@ z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/5
 $ rad comment d4ef85f57a849bd845915d7a66a2192cd23811f6 --message 'I cannot wait to get back to the 90s!' --reply-to z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/5
 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6
 ```
+
+Now, let's checkout the patch that we just created:
+
+```
+$ rad patch checkout d4ef85f57a849bd845915d7a66a2192cd23811f6
+ok Performing patch checkout...
+ok Switched to branch patch/d4ef85f57a8
+```

--- a/radicle-cli/src/commands/patch/checkout.rs
+++ b/radicle-cli/src/commands/patch/checkout.rs
@@ -1,0 +1,40 @@
+use crate::terminal as term;
+use anyhow::anyhow;
+use radicle::cob::patch::{self, PatchId};
+use radicle::git::{self, RefString};
+use radicle::profile::Profile;
+use radicle::storage::git::Repository;
+
+pub fn run(
+    storage: &Repository,
+    profile: &Profile,
+    git_workdir: &git::raw::Repository,
+    patch_id: &PatchId,
+) -> anyhow::Result<()> {
+    let patches = patch::Patches::open(profile.public_key, storage)?;
+    let patch = patches
+        .get(patch_id)?
+        .ok_or_else(|| anyhow!("Patch `{patch_id}` not found"))?;
+
+    let spinner = term::spinner("Performing patch checkout...");
+
+    // Getting the patch obj!
+    let patch_head = *patch.head();
+    let commit = git_workdir.find_commit(patch_head.into())?;
+
+    let name = RefString::try_from(format!("patch/{}", term::format::cob(patch_id)))?;
+    let branch = git::refs::workdir::branch(&name);
+    // checkout the patch in a new branch!
+    git_workdir.branch(branch.as_str(), &commit, false)?;
+    // and then point the current `HEAD` inside the new branch.
+    git_workdir.set_head(branch.as_str())?;
+    spinner.finish();
+
+    // 3. Write to the UI Terminal
+    term::success!(
+        "Switched to branch {}",
+        term::format::highlight(name.as_str())
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This implements the `patch checkout <patch id>` command and updates the tests

I was thinking to add an cli flag to customize the branch name, but I guess this could be done later