### PR TITLE
Make `ReadStorage` more usable

### DIFF
--- a/radicle-cli/src/commands/assign.rs
+++ b/radicle-cli/src/commands/assign.rs
@@ -83,7 +83,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let signer = term::signer(&profile)?;
     let storage = &profile.storage;
     let (_, id) = radicle::rad::cwd()?;
-    let repo = storage.repository(id)?;
+    let repo = storage.repository_mut(id)?;
     let mut issues = issue::Issues::open(*signer.public_key(), &repo)?;
 
     let mut issue = issues.get_mut(&options.id).map_err(|err| match err {

--- a/radicle-cli/src/commands/checkout.rs
+++ b/radicle-cli/src/commands/checkout.rs
@@ -7,7 +7,6 @@ use anyhow::Context as _;
 use radicle::prelude::*;
 use radicle::storage::git::transport;
 use radicle::storage::RemoteId;
-use radicle::storage::WriteStorage;
 
 use crate::project;
 use crate::terminal as term;

--- a/radicle-cli/src/commands/clone.rs
+++ b/radicle-cli/src/commands/clone.rs
@@ -15,7 +15,6 @@ use radicle::prelude::*;
 use radicle::rad;
 use radicle::storage;
 use radicle::storage::git::{ProjectError, Storage};
-use radicle::storage::WriteStorage;
 
 use crate::commands::rad_checkout as checkout;
 use crate::project;

--- a/radicle-cli/src/commands/comment.rs
+++ b/radicle-cli/src/commands/comment.rs
@@ -10,7 +10,6 @@ use radicle::cob::store;
 use radicle::cob::thread;
 use radicle::prelude::*;
 use radicle::storage;
-use radicle::storage::WriteStorage;
 
 use crate::terminal as term;
 use crate::terminal::args::{Args, Error, Help};

--- a/radicle-cli/src/commands/delegate/add.rs
+++ b/radicle-cli/src/commands/delegate/add.rs
@@ -19,7 +19,7 @@ where
         .get(&profile.public_key, id)?
         .context("No project with such ID exists")?;
 
-    let repo = storage.repository(id)?;
+    let repo = storage.repository_mut(id)?;
 
     if !project.is_delegate(me) {
         return Err(anyhow::anyhow!(

--- a/radicle-cli/src/commands/delegate/remove.rs
+++ b/radicle-cli/src/commands/delegate/remove.rs
@@ -19,7 +19,7 @@ where
         .get(&profile.public_key, id)?
         .context("No project with such ID exists")?;
 
-    let repo = storage.repository(id)?;
+    let repo = storage.repository_mut(id)?;
 
     if !project.is_delegate(me) {
         return Err(anyhow::anyhow!(

--- a/radicle-cli/src/commands/edit.rs
+++ b/radicle-cli/src/commands/edit.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context as _};
 
 use radicle::identity::Id;
-use radicle::storage::{ReadStorage, WriteRepository, WriteStorage};
+use radicle::storage::{ReadStorage, WriteRepository};
 
 use crate::terminal as term;
 use crate::terminal::args::{Args, Error, Help};

--- a/radicle-cli/src/commands/id.rs
+++ b/radicle-cli/src/commands/id.rs
@@ -5,7 +5,7 @@ use radicle::cob::identity::{self, Proposal, ProposalId, Proposals, Revision, Re
 use radicle::git::Oid;
 use radicle::identity::Identity;
 use radicle::prelude::Doc;
-use radicle::storage::WriteStorage as _;
+use radicle::storage::ReadStorage as _;
 use radicle_crypto::{PublicKey, Verified};
 
 use crate::terminal::args::{Args, Error, Help};

--- a/radicle-cli/src/commands/inspect.rs
+++ b/radicle-cli/src/commands/inspect.rs
@@ -11,7 +11,7 @@ use json_color::{Color, Colorizer};
 use radicle::crypto::Unverified;
 use radicle::identity::Untrusted;
 use radicle::identity::{Doc, Id};
-use radicle::storage::{ReadRepository, ReadStorage, WriteStorage};
+use radicle::storage::{ReadRepository, ReadStorage};
 
 use crate::terminal as term;
 use crate::terminal::args::{Args, Error, Help};

--- a/radicle-cli/src/commands/issue.rs
+++ b/radicle-cli/src/commands/issue.rs
@@ -198,7 +198,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let signer = term::signer(&profile)?;
     let storage = &profile.storage;
     let (_, id) = radicle::rad::cwd()?;
-    let repo = storage.repository(id)?;
+    let repo = storage.repository_mut(id)?;
     let mut issues = Issues::open(*signer.public_key(), &repo)?;
 
     match options.op {

--- a/radicle-cli/src/commands/ls.rs
+++ b/radicle-cli/src/commands/ls.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use crate::terminal as term;
 use crate::terminal::args::{Args, Error, Help};
 
-use radicle::storage::{ReadRepository, WriteStorage};
+use radicle::storage::{ReadRepository, ReadStorage};
 
 pub const HELP: Help = Help {
     name: "ls",

--- a/radicle-cli/src/commands/track.rs
+++ b/radicle-cli/src/commands/track.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Context as _};
 
 use radicle::node::{Handle, NodeId};
-use radicle::storage::WriteStorage;
+use radicle::storage::ReadStorage;
 
 use crate::terminal as term;
 use crate::terminal::args::{Args, Error, Help};

--- a/radicle-cli/src/commands/unassign.rs
+++ b/radicle-cli/src/commands/unassign.rs
@@ -83,7 +83,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let signer = term::signer(&profile)?;
     let storage = &profile.storage;
     let (_, id) = radicle::rad::cwd()?;
-    let repo = storage.repository(id)?;
+    let repo = storage.repository_mut(id)?;
     let mut issues = issue::Issues::open(*signer.public_key(), &repo)?;
 
     let mut issue = issues.get_mut(&options.id).map_err(|err| match err {

--- a/radicle-cli/src/commands/untrack.rs
+++ b/radicle-cli/src/commands/untrack.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Context as _};
 use radicle::identity::Id;
 use radicle::node::Handle;
 use radicle::prelude::*;
-use radicle::storage::WriteStorage;
+use radicle::storage::ReadStorage;
 
 use crate::terminal as term;
 use crate::terminal::args::{Args, Error, Help};

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -6,7 +6,7 @@ use std::{thread, time};
 use radicle::git;
 use radicle::prelude::Id;
 use radicle::profile::Home;
-use radicle::storage::{ReadRepository, WriteStorage};
+use radicle::storage::{ReadRepository, ReadStorage};
 use radicle::test::fixtures;
 
 use radicle_cli_test::TestFormula;

--- a/radicle-httpd/src/api.rs
+++ b/radicle-httpd/src/api.rs
@@ -14,7 +14,7 @@ use tower_http::cors::{self, CorsLayer};
 
 use radicle::cob::issue::Issues;
 use radicle::identity::Id;
-use radicle::storage::{ReadRepository, WriteStorage};
+use radicle::storage::{ReadRepository, ReadStorage};
 use radicle::Profile;
 
 mod auth;

--- a/radicle-httpd/src/api/test.rs
+++ b/radicle-httpd/src/api/test.rs
@@ -13,7 +13,7 @@ use tower::ServiceExt;
 use radicle::cob::issue::Issues;
 use radicle::cob::patch::{MergeTarget, Patches};
 use radicle::git::raw as git2;
-use radicle::storage::WriteStorage;
+use radicle::storage::ReadStorage;
 use radicle_cli::commands::rad_init;
 use radicle_crypto::ssh::keystore::MemorySigner;
 use radicle_crypto::Signer;

--- a/radicle-httpd/src/api/v1/delegates.rs
+++ b/radicle-httpd/src/api/v1/delegates.rs
@@ -5,7 +5,7 @@ use axum::{Json, Router};
 
 use radicle::cob::issue::Issues;
 use radicle::identity::Did;
-use radicle::storage::{ReadRepository, WriteStorage};
+use radicle::storage::{ReadRepository, ReadStorage};
 
 use crate::api::axum_extra::{Path, Query};
 use crate::api::error::Error;

--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -17,7 +17,7 @@ use radicle::cob::patch::Patches;
 use radicle::cob::{thread, ActorId, Tag};
 use radicle::identity::Id;
 use radicle::node::NodeId;
-use radicle::storage::{git::paths, ReadRepository, WriteStorage};
+use radicle::storage::{git::paths, ReadRepository, ReadStorage};
 use radicle_surf::{Glob, Oid, Repository};
 
 use crate::api::axum_extra::{Path, Query};

--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -2,7 +2,7 @@ use std::{thread, time};
 
 use radicle::crypto::Signer;
 use radicle::node::{FetchResult, Handle as _};
-use radicle::storage::{ReadRepository, WriteStorage};
+use radicle::storage::{ReadRepository, ReadStorage};
 use radicle::{assert_matches, rad};
 
 use crate::service;

--- a/radicle-remote-helper/src/lib.rs
+++ b/radicle-remote-helper/src/lib.rs
@@ -55,7 +55,7 @@ pub fn run(profile: radicle::Profile) -> Result<(), Box<dyn std::error::Error + 
     // Default to profile key.
     let namespace = url.namespace.unwrap_or(profile.public_key);
 
-    let proj = profile.storage.repository(url.repo)?;
+    let proj = profile.storage.repository_mut(url.repo)?;
     if proj.is_empty()? {
         return Err(Error::RepositoryNotFound(proj.path().to_path_buf()).into());
     }

--- a/radicle-tools/src/rad-push.rs
+++ b/radicle-tools/src/rad-push.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use radicle::{node::Handle, storage::WriteRepository, storage::WriteStorage};
+use radicle::{node::Handle, storage::ReadStorage, storage::WriteRepository};
 
 fn main() -> anyhow::Result<()> {
     let cwd = Path::new(".").canonicalize()?;

--- a/radicle/src/identity.rs
+++ b/radicle/src/identity.rs
@@ -154,7 +154,7 @@ mod test {
     use crate::crypto::PublicKey;
     use crate::rad;
     use crate::storage::git::Storage;
-    use crate::storage::{ReadStorage, WriteRepository, WriteStorage};
+    use crate::storage::{ReadStorage, WriteRepository};
     use crate::test::fixtures;
 
     use super::did::Did;

--- a/radicle/src/identity/doc.rs
+++ b/radicle/src/identity/doc.rs
@@ -371,7 +371,7 @@ mod test {
     use crate::rad;
     use crate::storage::git::transport;
     use crate::storage::git::Storage;
-    use crate::storage::WriteStorage;
+    use crate::storage::WriteStorage as _;
     use crate::test::arbitrary;
     use crate::test::fixtures;
 
@@ -414,7 +414,7 @@ mod test {
         let storage = Storage::open(tempdir.path().join("storage")).unwrap();
         let remote = arbitrary::gen::<RemoteId>(1);
         let proj = arbitrary::gen::<Id>(1);
-        let repo = storage.repository(proj).unwrap();
+        let repo = storage.create(proj).unwrap();
         let oid = git2::Oid::from_str("2d52a53ce5e4f141148a5f770cfd3ead2d6a45b8").unwrap();
 
         let err = Doc::<Unverified>::head(&remote, &repo).unwrap_err();

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -14,7 +14,8 @@ use crate::identity::project::Project;
 use crate::storage::git::transport;
 use crate::storage::git::{ProjectError, Repository, Storage};
 use crate::storage::refs::SignedRefs;
-use crate::storage::{BranchName, ReadRepository as _, RemoteId, WriteRepository as _};
+use crate::storage::WriteRepository;
+use crate::storage::{BranchName, ReadRepository as _, RemoteId};
 use crate::{identity, storage};
 
 /// Name of the radicle storage remote.
@@ -129,7 +130,7 @@ pub fn fork_remote<G: Signer, S: storage::WriteStorage>(
         .get(remote, proj)?
         .ok_or(ForkError::NotFound(proj))?;
     let project = doc.project()?;
-    let repository = storage.repository(proj)?;
+    let repository = storage.repository_mut(proj)?;
 
     let raw = repository.raw();
     let remote_head = raw.refname_to_id(&git::refs::storage::branch(
@@ -162,7 +163,7 @@ pub fn fork<G: Signer, S: storage::WriteStorage>(
     storage: &S,
 ) -> Result<(), ForkError> {
     let me = signer.public_key();
-    let repository = storage.repository(proj)?;
+    let repository = storage.repository_mut(proj)?;
     // TODO: We should get the id branch pointer from a stored canonical reference.
     let (canonical_id, _) = repository.identity_doc()?;
     let (canonical_branch, canonical_head) = repository.head()?;
@@ -302,7 +303,7 @@ mod tests {
     use crate::identity::Did;
     use crate::storage::git::transport;
     use crate::storage::git::Storage;
-    use crate::storage::{ReadStorage, WriteStorage};
+    use crate::storage::ReadStorage;
     use crate::test::fixtures;
 
     use super::*;

--- a/radicle/src/test/storage.rs
+++ b/radicle/src/test/storage.rs
@@ -32,6 +32,8 @@ impl MockStorage {
 }
 
 impl ReadStorage for MockStorage {
+    type Repository = MockRepository;
+
     fn path(&self) -> &Path {
         self.path.as_path()
     }
@@ -51,12 +53,20 @@ impl ReadStorage for MockStorage {
     fn inventory(&self) -> Result<Inventory, Error> {
         Ok(self.inventory.keys().cloned().collect::<Vec<_>>())
     }
+
+    fn repository(&self, _proj: Id) -> Result<Self::Repository, Error> {
+        Ok(MockRepository {})
+    }
 }
 
 impl WriteStorage for MockStorage {
-    type Repository = MockRepository;
+    type RepositoryMut = MockRepository;
 
-    fn repository(&self, _proj: Id) -> Result<Self::Repository, Error> {
+    fn repository_mut(&self, _rid: Id) -> Result<Self::RepositoryMut, Error> {
+        Ok(MockRepository {})
+    }
+
+    fn create(&self, _rid: Id) -> Result<Self::RepositoryMut, Error> {
         Ok(MockRepository {})
     }
 }


### PR DESCRIPTION
Previously, we were not able to access a `ReadRepository` instance through `ReadStorage`. With this change, we are able to.