### PR TITLE
radicle: canonicalize home path

### DIFF
--- a/radicle-node/src/test/environment.rs
+++ b/radicle-node/src/test/environment.rs
@@ -71,9 +71,7 @@ impl Environment {
     /// Create a new profile in this environment.
     /// This should be used when a running node is not required.
     pub fn profile(&mut self, name: &str) -> Profile {
-        let home = Home::new(self.tmp().join("home").join(name))
-            .init()
-            .unwrap();
+        let home = Home::new(self.tmp().join("home").join(name)).unwrap();
         let storage = Storage::open(home.storage()).unwrap();
         let keystore = Keystore::new(&home.keys());
         let keypair = KeyPair::from_seed(Seed::from([!(self.users as u8); 32]));
@@ -232,7 +230,7 @@ impl Node<MockSigner> {
                 .take(8)
                 .collect::<String>(),
         );
-        let home = Home::new(home).init().unwrap();
+        let home = Home::new(home).unwrap();
         let signer = MockSigner::default();
         let storage = Storage::open(home.storage()).unwrap();
 

--- a/radicle/src/test.rs
+++ b/radicle/src/test.rs
@@ -19,7 +19,7 @@ pub mod setup {
         let mut rng = fastrand::Rng::new();
         let signer = MockSigner::new(&mut rng);
         let home = tmp.path().join("home");
-        let paths = Home::new(home.as_path());
+        let paths = Home::new(home.as_path()).unwrap();
         let storage = Storage::open(paths.storage()).unwrap();
         let (id, _, _, _) = fixtures::project(tmp.path().join("copy"), &storage, &signer).unwrap();
         let project = storage.repository(id).unwrap();


### PR DESCRIPTION
If a path was passed to `Home` in non-canonical form it would not use the right path for any initialisation or use.

The aim is to use the `canonicalize` function for paths. However, this may return an error if none of the paths exist. To ensure that the path exists the `new` constructor for `Home` creates the directory and canonicalizes the path.

Since `new` now initialises the home directory, it would be useful if it also initialised all the necessary subdirectories -- which removes the need for the `init` method.

Fixes #313 