### PR TITLE
node: Remove redundant handshake

### DIFF
--- a/radicle-node/src/service/message.rs
+++ b/radicle-node/src/service/message.rs
@@ -309,9 +309,6 @@ impl Announcement {
 /// These are the messages peers send to each other.
 #[derive(Clone, PartialEq, Eq)]
 pub enum Message {
-    /// The first message sent to a peer after connection.
-    Initialize { node_id: NodeId },
-
     /// Subscribe to gossip messages matching the filter and time range.
     Subscribe(Subscribe),
 
@@ -339,10 +336,6 @@ pub enum Message {
 }
 
 impl Message {
-    pub fn init(node_id: NodeId) -> Self {
-        Self::Initialize { node_id }
-    }
-
     pub fn announcement(
         node: NodeId,
         message: impl Into<AnnouncementMessage>,
@@ -412,7 +405,6 @@ impl From<Announcement> for Message {
 impl fmt::Debug for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Initialize { .. } => write!(f, "Initialize(..)"),
             Self::Subscribe(Subscribe { since, until, .. }) => {
                 write!(f, "Subscribe({since}..{until})")
             }

--- a/radicle-node/src/service/session.rs
+++ b/radicle-node/src/service/session.rs
@@ -41,8 +41,6 @@ pub enum State {
     Connecting,
     /// Initial state after handshake protocol hand-off.
     Connected {
-        /// Whether this session was initialized with a [`Message::Initialize`].
-        initialized: bool,
         /// Connected since this time.
         since: LocalTime,
         /// Ping state.
@@ -167,7 +165,6 @@ impl Session {
         Self {
             id,
             state: State::Connected {
-                initialized: false,
                 since: time,
                 ping: PingState::default(),
                 protocol: Protocol::default(),
@@ -191,16 +188,6 @@ impl Session {
 
     pub fn is_disconnected(&self) -> bool {
         matches!(self.state, State::Disconnected { .. })
-    }
-
-    pub fn is_negotiated(&self) -> bool {
-        matches!(
-            self.state,
-            State::Connected {
-                initialized: true,
-                ..
-            }
-        )
     }
 
     pub fn is_gossip_allowed(&self) -> bool {
@@ -279,7 +266,6 @@ impl Session {
         );
         self.attempts = 0;
         self.state = State::Connected {
-            initialized: false,
             since,
             ping: PingState::default(),
             protocol: Protocol::default(),

--- a/radicle-node/src/test/environment.rs
+++ b/radicle-node/src/test/environment.rs
@@ -138,11 +138,11 @@ impl<G: Signer + cyphernet::Ecdh> NodeHandle<G> {
             let remote_sessions = remote.handle.sessions().unwrap();
 
             let local_sessions = local_sessions
-                .negotiated()
+                .connected()
                 .map(|(id, _)| id)
                 .collect::<BTreeSet<_>>();
             let remote_sessions = remote_sessions
-                .negotiated()
+                .connected()
                 .map(|(id, _)| id)
                 .collect::<BTreeSet<_>>();
 

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -243,11 +243,8 @@ where
 
         self.initialize();
         self.service.connected(remote_id, Link::Inbound);
-        self.receive(remote_id, Message::init(remote_id));
 
         let mut msgs = self.messages(remote_id);
-        msgs.find(|m| matches!(m, Message::Initialize { .. }))
-            .expect("`initialize` must be sent");
         msgs.find(|m| {
             matches!(
                 m,
@@ -269,8 +266,6 @@ where
         self.service.connected(remote_id, Link::Outbound);
 
         let mut msgs = self.messages(remote_id);
-        msgs.find(|m| matches!(m, Message::Initialize { .. }))
-            .expect("`initialize` must be sent");
         msgs.find(|m| {
             matches!(
                 m,
@@ -281,8 +276,6 @@ where
             )
         })
         .expect("`inventory-announcement` must be sent");
-
-        self.receive(remote_id, Message::init(remote_id));
     }
 
     pub fn elapse(&mut self, duration: LocalDuration) {

--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -100,7 +100,7 @@ fn test_disconnecting_unresponsive_peer() {
     let bob = Peer::new("bob", [9, 9, 9, 9]);
 
     alice.connect_to(&bob);
-    assert_eq!(1, alice.sessions().negotiated().count(), "bob connects");
+    assert_eq!(1, alice.sessions().connected().count(), "bob connects");
     alice.elapse(STALE_CONNECTION_TIMEOUT + LocalDuration::from_secs(1));
     alice
         .outbox()
@@ -122,7 +122,7 @@ fn test_connection_kept_alive() {
 
     alice.command(service::Command::Connect(bob.id(), bob.address()));
     sim.run_while([&mut alice, &mut bob], |s| !s.is_settled());
-    assert_eq!(1, alice.sessions().negotiated().count(), "bob connects");
+    assert_eq!(1, alice.sessions().connected().count(), "bob connects");
 
     let mut elapsed: LocalDuration = LocalDuration::from_secs(0);
     let step: LocalDuration = STALE_CONNECTION_TIMEOUT / 10;
@@ -150,7 +150,7 @@ fn test_outbound_connection() {
     let peers = alice
         .service
         .sessions()
-        .negotiated()
+        .connected()
         .map(|(id, _)| *id)
         .collect::<Vec<_>>();
 
@@ -170,7 +170,7 @@ fn test_inbound_connection() {
     let peers = alice
         .service
         .sessions()
-        .negotiated()
+        .connected()
         .map(|(id, _)| *id)
         .collect::<Vec<_>>();
 
@@ -795,7 +795,7 @@ fn test_persistent_peer_reconnect_attempt() {
 
     let ips = alice
         .sessions()
-        .negotiated()
+        .connected()
         .map(|(id, _)| *id)
         .collect::<Vec<_>>();
     assert!(ips.contains(&bob.id()));


### PR DESCRIPTION
With `NoiseXK` handshake implemented, there is no longer a need to have an `Initialize` message and an extra state in the session.