### PR TITLE
Use `Did` across CLI tooling

### DIFF
--- a/radicle-cli/examples/rad-auth.md
+++ b/radicle-cli/examples/rad-auth.md
@@ -7,7 +7,7 @@ $ rad auth
 Initializing your 🌱 profile and identity
 
 ok Creating your 🌱 Ed25519 keypair...
-ok Profile z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi created.
+ok Profile did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi created.
 
 Your radicle Node ID is z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi. This identifies your device.
 
@@ -18,7 +18,8 @@ You can get the above information at all times using the `self` command:
 
 ```
 $ rad self
-ID             z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+ID             did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+Node ID        z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 Key (hash)     SHA256:UIedaL6Cxm6OUErh9GQUzzglSk7VpQlVTI1TAFB/HWA
 Key (full)     AAAAC3NzaC1lZDI1NTE5AAAAIHahWSBEpuT1ESZbynOmBNkLBSnR32Ar4woZqSV2YNH1
 Storage (git)  [..]/storage

--- a/radicle-cli/examples/rad-delegate.md
+++ b/radicle-cli/examples/rad-delegate.md
@@ -14,7 +14,7 @@ We want to add a new maintainer to the project to help out with the
 work.
 
 ```
-$ rad delegate add z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG --to rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+$ rad delegate add did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG --to rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
 Added delegate 'did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG'
 ok Update successful!
 ```
@@ -33,7 +33,7 @@ And finally, we no longer want to be part of the project so we pass on
 the torch and remove ourselves from the delegate set.
 
 ```
-$ rad delegate remove z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi --to rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+$ rad delegate remove did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi --to rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
 Removed delegate 'did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi'
 ok Update successful!
 ```

--- a/radicle-cli/examples/rad-id-rebase.md
+++ b/radicle-cli/examples/rad-id-rebase.md
@@ -5,7 +5,7 @@ First off, we will create two proposals -- we can imagine two
 delegates creating proposals concurrently.
 
 ```
-$ rad id edit --title "Add Alice" --description "Add Alice as a delegate" --delegates z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
+$ rad id edit --title "Add Alice" --description "Add Alice as a delegate" --delegates did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
 ok Identity proposal '57332790a2eabc0b2fd8c7ff48c3579d5812d405' created 🌱
 title: Add Alice
 description: Add Alice as a delegate
@@ -47,7 +47,7 @@ Quorum Reached
 ```
 
 ```
-$ rad id edit --title "Add Bob" --description "Add Bob as a delegate" --delegates z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG --no-confirm
+$ rad id edit --title "Add Bob" --description "Add Bob as a delegate" --delegates did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG --no-confirm
 ok Identity proposal 'c3698d4e85f9d4c0ee536b34d6122fc7c81f7e2e' created 🌱
 title: Add Bob
 description: Add Bob as a delegate
@@ -294,7 +294,7 @@ Quorum Reached
 We can now update the proposal to have both keys in the delegates set:
 
 ```
-$ rad id update c3698d4e85f9d4c0ee536b34d6122fc7c81f7e2e --rev z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/4 --delegates z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
+$ rad id update c3698d4e85f9d4c0ee536b34d6122fc7c81f7e2e --rev z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/4 --delegates did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
 ok Identity proposal 'c3698d4e85f9d4c0ee536b34d6122fc7c81f7e2e' updated 🌱
 ok Revision 'z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi/6'
 title: Add Bob

--- a/radicle-cli/examples/rad-id.md
+++ b/radicle-cli/examples/rad-id.md
@@ -9,11 +9,11 @@ delegate` command. For cases where `threshold > 1`, it is necessary to
 gather a quorum of signatures to update the Radicle identity. To do
 this, we use the `rad id` command.
 
-Let's add Bob as a delegate using their key
-`z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn`.
+Let's add Bob as a delegate using their DID
+`did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn`.
 
 ```
-$ rad id edit --title "Add Bob" --description "Add Bob as a delegate" --delegates z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
+$ rad id edit --title "Add Bob" --description "Add Bob as a delegate" --delegates did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
 ok Identity proposal '06d9efa2a9aad06bfdf25a25690e1ec7db2c3c39' created 🌱
 title: Add Bob
 description: Add Bob as a delegate

--- a/radicle-cli/examples/rad-issue.md
+++ b/radicle-cli/examples/rad-issue.md
@@ -22,20 +22,20 @@ others to work on.  This is to ensure work is not duplicated.
 Let's assign ourselves to this one.
 
 ```
-$ rad assign 2b4650e3c66d568132034de0d02871a2fbf9c5b5 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad assign 2b4650e3c66d568132034de0d02871a2fbf9c5b5 did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 It will now show in the list of issues assigned to us.
 
 ```
 $ rad issue list --assigned
-2b4650e3c66d568132034de0d02871a2fbf9c5b5 "flux capacitor underpowered" z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+2b4650e3c66d568132034de0d02871a2fbf9c5b5 "flux capacitor underpowered" did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Note: this can always be undone with the `unassign` subcommand.
 
 ```
-$ rad unassign 2b4650e3c66d568132034de0d02871a2fbf9c5b5 z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad unassign 2b4650e3c66d568132034de0d02871a2fbf9c5b5 did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Great, now we have communicated to the world about our car's defect.

--- a/radicle-cli/src/commands/assign.rs
+++ b/radicle-cli/src/commands/assign.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::str::FromStr;
 
 use anyhow::anyhow;
+use radicle::prelude::Did;
 
 use crate::terminal as term;
 use crate::terminal::args;
@@ -16,7 +17,7 @@ pub const HELP: args::Help = args::Help {
     usage: r#"
 Usage
 
-    rad assign <issue> <peer>
+    rad assign <issue> <did>
 
 Options
 
@@ -27,7 +28,7 @@ Options
 #[derive(Debug)]
 pub struct Options {
     pub id: issue::IssueId,
-    pub peer: cob::ActorId,
+    pub peer: Did,
 }
 
 impl args::Args for Options {
@@ -36,7 +37,7 @@ impl args::Args for Options {
 
         let mut parser = lexopt::Parser::from_args(args);
         let mut id: Option<issue::IssueId> = None;
-        let mut peer: Option<cob::ActorId> = None;
+        let mut peer: Option<Did> = None;
 
         while let Some(arg) = parser.next()? {
             match arg {
@@ -52,12 +53,7 @@ impl args::Args for Options {
 
                         id = Some(val);
                     } else if peer.is_none() {
-                        let val = val.to_string_lossy();
-                        let Ok(val) = cob::ActorId::from_str(&val) else {
-                            return Err(anyhow!("invalid peer ID '{}'", val));
-                        };
-
-                        peer = Some(val);
+                        peer = Some(term::args::did(val)?);
                     } else {
                         return Err(anyhow!(arg.unexpected()));
                     }
@@ -90,7 +86,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         cob::store::Error::NotFound(_, _) => anyhow!("issue not found '{}'", options.id),
         _ => err.into(),
     })?;
-    issue.assign(vec![options.peer], &signer)?;
+    issue.assign(vec![*options.peer], &signer)?;
 
     Ok(())
 }

--- a/radicle-cli/src/commands/auth.rs
+++ b/radicle-cli/src/commands/auth.rs
@@ -87,7 +87,7 @@ pub fn init(options: Options) -> anyhow::Result<()> {
 
     term::success!(
         "Profile {} created.",
-        term::format::highlight(profile.id().to_string())
+        term::format::highlight(profile.did().to_string())
     );
 
     term::blank();

--- a/radicle-cli/src/commands/checkout.rs
+++ b/radicle-cli/src/commands/checkout.rs
@@ -60,10 +60,7 @@ impl Args for Options {
                     }
                 }
                 Value(val) if id.is_none() => {
-                    let val = val.to_string_lossy();
-                    let val = Id::from_str(&val).context(format!("invalid id '{val}'"))?;
-
-                    id = Some(val);
+                    id = Some(term::args::rid(&val)?);
                 }
                 _ => return Err(anyhow::anyhow!(arg.unexpected())),
             }

--- a/radicle-cli/src/commands/delegate.rs
+++ b/radicle-cli/src/commands/delegate.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsString;
-use std::str::FromStr;
 
 use anyhow::{anyhow, Context as _};
 
@@ -86,13 +85,7 @@ impl Args for Options {
                         did = Some(term::args::did(&val)?);
                     }
                     Some(OperationName::List) => {
-                        // TODO: create args::project_id function
-                        let val = val.to_string_lossy();
-                        if let Ok(val) = Id::from_str(&val) {
-                            id = Some(val);
-                        } else {
-                            return Err(anyhow!("invalid Project ID '{}'", val));
-                        }
+                        id = Some(term::args::rid(&val)?);
                     }
                     None => continue,
                 },

--- a/radicle-cli/src/commands/edit.rs
+++ b/radicle-cli/src/commands/edit.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsString;
-use std::str::FromStr;
 
 use anyhow::{anyhow, Context as _};
 
@@ -45,13 +44,7 @@ impl Args for Options {
                     return Err(Error::Help.into());
                 }
                 Value(val) if id.is_none() => {
-                    let val = val.to_string_lossy();
-
-                    if let Ok(val) = Id::from_str(&val) {
-                        id = Some(val);
-                    } else {
-                        return Err(anyhow!("invalid ID '{}'", val));
-                    }
+                    id = Some(term::args::rid(&val)?);
                 }
                 _ => return Err(anyhow::anyhow!(arg.unexpected())),
             }

--- a/radicle-cli/src/commands/rm.rs
+++ b/radicle-cli/src/commands/rm.rs
@@ -1,6 +1,5 @@
 use std::ffi::OsString;
 use std::fs;
-use std::str::FromStr;
 
 use anyhow::anyhow;
 
@@ -52,13 +51,7 @@ impl Args for Options {
                     return Err(Error::Help.into());
                 }
                 Value(val) if id.is_none() => {
-                    let val = val.to_string_lossy();
-
-                    if let Ok(val) = Id::from_str(&val) {
-                        id = Some(val);
-                    } else {
-                        return Err(anyhow!("invalid ID '{}'", val));
-                    }
+                    id = Some(term::args::rid(&val)?);
                 }
                 _ => return Err(anyhow::anyhow!(arg.unexpected())),
             }

--- a/radicle-cli/src/commands/self.rs
+++ b/radicle-cli/src/commands/self.rs
@@ -77,8 +77,11 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
 fn all(profile: &Profile) -> anyhow::Result<()> {
     let mut table = term::Table::default();
 
+    let did = profile.did();
+    table.push(["ID", &term::format::tertiary(did)]);
+
     let node_id = profile.id();
-    table.push(["ID", &term::format::tertiary(node_id)]);
+    table.push(["Node ID", &term::format::tertiary(node_id)]);
 
     let ssh_short = ssh::fmt::fingerprint(node_id);
     table.push(["Key (hash)", &term::format::tertiary(ssh_short)]);

--- a/radicle-cli/src/terminal/args.rs
+++ b/radicle-cli/src/terminal/args.rs
@@ -74,7 +74,7 @@ pub fn finish(unparsed: Vec<OsString>) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn did(val: OsString) -> anyhow::Result<Did> {
+pub fn did(val: &OsString) -> anyhow::Result<Did> {
     let val = val.to_string_lossy();
     let Ok(peer) = Did::from_str(&val) else {
         if crypto::PublicKey::from_str(&val).is_ok() {

--- a/radicle-cli/src/terminal/args.rs
+++ b/radicle-cli/src/terminal/args.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use anyhow::anyhow;
 use radicle::crypto;
-use radicle::prelude::Did;
+use radicle::prelude::{Did, Id};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -84,4 +84,9 @@ pub fn did(val: &OsString) -> anyhow::Result<Did> {
         }
     };
     Ok(peer)
+}
+
+pub fn rid(val: &OsString) -> anyhow::Result<Id> {
+    let val = val.to_string_lossy();
+    Id::from_str(&val).map_err(|_| anyhow!("invalid repository ID '{}'", val))
 }

--- a/radicle-cli/src/terminal/args.rs
+++ b/radicle-cli/src/terminal/args.rs
@@ -2,6 +2,8 @@ use std::ffi::OsString;
 use std::str::FromStr;
 
 use anyhow::anyhow;
+use radicle::crypto;
+use radicle::prelude::Did;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -70,4 +72,16 @@ pub fn finish(unparsed: Vec<OsString>) -> anyhow::Result<()> {
         ));
     }
     Ok(())
+}
+
+pub fn did(val: OsString) -> anyhow::Result<Did> {
+    let val = val.to_string_lossy();
+    let Ok(peer) = Did::from_str(&val) else {
+        if crypto::PublicKey::from_str(&val).is_ok() {
+            return Err(anyhow!("expected DID, did you mean 'did:key:{val}'?"));
+        } else {
+            return Err(anyhow!("invalid DID '{}', expected 'did:key'", val));
+        }
+    };
+    Ok(peer)
 }

--- a/radicle/src/cob/issue.rs
+++ b/radicle/src/cob/issue.rs
@@ -16,6 +16,7 @@ use crate::cob::thread;
 use crate::cob::thread::{CommentId, Thread};
 use crate::cob::{store, ActorId, ObjectId, OpId, TypeName};
 use crate::crypto::{PublicKey, Signer};
+use crate::prelude::Did;
 use crate::storage::git as storage;
 
 /// Issue operation.
@@ -152,8 +153,8 @@ impl store::FromHistory for Issue {
 }
 
 impl Issue {
-    pub fn assigned(&self) -> impl Iterator<Item = &ActorId> {
-        self.assignees.iter()
+    pub fn assigned(&self) -> impl Iterator<Item = Did> + '_ {
+        self.assignees.iter().map(Did::from)
     }
 
     pub fn title(&self) -> &str {
@@ -516,21 +517,21 @@ mod test {
 
         let id = issue.id;
         let issue = issues.get(&id).unwrap().unwrap();
-        let assignees: Vec<_> = issue.assigned().cloned().collect::<Vec<_>>();
+        let assignees: Vec<_> = issue.assigned().collect::<Vec<_>>();
 
         assert_eq!(1, assignees.len());
-        assert!(assignees.contains(&assignee));
+        assert!(assignees.contains(&Did::from(assignee)));
 
         let mut issue = issues.get_mut(&id).unwrap();
         issue.assign([assignee_two], &signer).unwrap();
 
         let id = issue.id;
         let issue = issues.get(&id).unwrap().unwrap();
-        let assignees: Vec<_> = issue.assigned().cloned().collect::<Vec<_>>();
+        let assignees: Vec<_> = issue.assigned().collect::<Vec<_>>();
 
         assert_eq!(2, assignees.len());
-        assert!(assignees.contains(&assignee));
-        assert!(assignees.contains(&assignee_two));
+        assert!(assignees.contains(&Did::from(assignee)));
+        assert!(assignees.contains(&Did::from(assignee_two)));
     }
 
     #[test]
@@ -556,11 +557,11 @@ mod test {
 
         let id = issue.id;
         let issue = issues.get(&id).unwrap().unwrap();
-        let assignees: Vec<_> = issue.assigned().cloned().collect::<Vec<_>>();
+        let assignees: Vec<_> = issue.assigned().collect::<Vec<_>>();
 
         assert_eq!(2, assignees.len());
-        assert!(assignees.contains(&assignee));
-        assert!(assignees.contains(&assignee_two));
+        assert!(assignees.contains(&Did::from(assignee)));
+        assert!(assignees.contains(&Did::from(assignee_two)));
     }
 
     #[test]
@@ -641,10 +642,10 @@ mod test {
 
         let id = issue.id;
         let issue = issues.get(&id).unwrap().unwrap();
-        let assignees: Vec<_> = issue.assigned().cloned().collect::<Vec<_>>();
+        let assignees: Vec<_> = issue.assigned().collect::<Vec<_>>();
 
         assert_eq!(1, assignees.len());
-        assert!(assignees.contains(&assignee_two));
+        assert!(assignees.contains(&Did::from(assignee_two)));
     }
 
     #[test]

--- a/radicle/src/identity/did.rs
+++ b/radicle/src/identity/did.rs
@@ -46,9 +46,23 @@ impl From<crypto::PublicKey> for Did {
     }
 }
 
+impl From<Did> for crypto::PublicKey {
+    fn from(Did(key): Did) -> Self {
+        key
+    }
+}
+
 impl From<Did> for String {
     fn from(other: Did) -> Self {
         other.encode()
+    }
+}
+
+impl FromStr for Did {
+    type Err = DidError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::decode(s)
     }
 }
 

--- a/radicle/src/profile.rs
+++ b/radicle/src/profile.rs
@@ -19,6 +19,7 @@ use crate::crypto::ssh::agent::Agent;
 use crate::crypto::ssh::{keystore, Keystore, Passphrase};
 use crate::crypto::{PublicKey, Signer};
 use crate::node;
+use crate::prelude::Did;
 use crate::storage::git::transport;
 use crate::storage::git::Storage;
 
@@ -101,6 +102,10 @@ impl Profile {
 
     pub fn id(&self) -> &PublicKey {
         &self.public_key
+    }
+
+    pub fn did(&self) -> Did {
+        Did::from(self.public_key)
     }
 
     pub fn signer(&self) -> Result<Box<dyn Signer>, Error> {


### PR DESCRIPTION
The aim of this proposal is to standardise the use of `Did` over `PublicKey`, `ActorId`, or `NodeId` when accepting arguments in the CLI as well as printing out the identifier during CLI execution.

In a couple of spots, I opted to keep the `NodeId` being printed out but also print out the `Did`.

Fixes #324 