### PR TITLE
radicle: exchange From for TryFrom for PathBuf and Home

### DIFF
--- a/radicle-httpd/src/api/test.rs
+++ b/radicle-httpd/src/api/test.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto as _;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -81,7 +82,8 @@ pub fn seed(dir: &Path) -> Context {
     .unwrap();
 
     // eq. rad auth
-    let profile = radicle::Profile::init(rad_home.into(), PASSWORD.to_owned()).unwrap();
+    let profile =
+        radicle::Profile::init(rad_home.try_into().unwrap(), PASSWORD.to_owned()).unwrap();
 
     // rad init
     rad_init::init(

--- a/radicle/src/profile.rs
+++ b/radicle/src/profile.rs
@@ -163,9 +163,11 @@ pub struct Home {
     path: PathBuf,
 }
 
-impl From<PathBuf> for Home {
-    fn from(path: PathBuf) -> Self {
-        Self { path }
+impl TryFrom<PathBuf> for Home {
+    type Error = io::Error;
+
+    fn try_from(home: PathBuf) -> Result<Self, Self::Error> {
+        Self::new(home)
     }
 }
 


### PR DESCRIPTION
The `From` implementation would allow someone to create a `Home` in an incorrect fashion, for example the path is not canonical.

Exchange `From` for a `TryFrom` implementation.
