### PR TITLE
Reject existing revisions

### DIFF
--- a/radicle-crdt/src/gmap.rs
+++ b/radicle-crdt/src/gmap.rs
@@ -33,6 +33,10 @@ impl<K: Ord, V: Semilattice> GMap<K, V> {
             }
         }
     }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.inner.contains_key(key)
+    }
 }
 
 impl<K: Ord, V: Semilattice> FromIterator<(K, V)> for GMap<K, V> {


### PR DESCRIPTION
If we have two operations, a = Reivision and b = Merge, then if we
have the following for any p = Patch then:

    p.apply([a, a, b]) =/= p.apply([a, b, a])

On the RHS we end up in the case that the reinserted Revision will
make the Revision redacted.

To stop this from happening, if a Revision is existing for the same
OpId then the `apply` is rejected.