### PR TITLE
Make dumped data structures more usable as input to tests

### DIFF
--- a/radicle-crdt/src/ord.rs
+++ b/radicle-crdt/src/ord.rs
@@ -5,9 +5,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::Semilattice;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Max<T>(T);
+
+impl<T: core::fmt::Debug> core::fmt::Debug for Max<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        // Just like the #[derive(Debug)] formatter, but without newlines to conserve screen space
+        // in large data structures.
+        write!(f, r#"Max({:?})"#, self.0)
+    }
+}
 
 impl<T> Max<T> {
     pub fn get(&self) -> &T {

--- a/radicle-crypto/src/lib.rs
+++ b/radicle-crypto/src/lib.rs
@@ -314,7 +314,7 @@ impl From<PublicKey> for String {
 
 impl fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "PublicKey({self})")
+        write!(f, r#"PublicKey::from_str("{self}").unwrap()"#)
     }
 }
 


### PR DESCRIPTION
Quickcheck generates large data structures.  Once they’re printed on stdout, a lot of redacting is necessary in order to use them as valid inputs in example-based tests.  These changes are supposed bridge that gap just a little so that printouts can be almost copy-pasted into test cases.