### PR TITLE
node: improve seeds information

### DIFF
--- a/radicle-cli/src/commands/clone.rs
+++ b/radicle-cli/src/commands/clone.rs
@@ -174,21 +174,21 @@ pub fn clone<G: Signer>(
     }
 
     // Get seeds. This consults the local routing table only.
-    let seeds = node.seeds(id)?;
-    if seeds.is_empty() {
+    let mut seeds = node.seeds(id)?;
+    if !seeds.has_connections() {
         return Err(CloneError::NotFound(id));
     }
     // Fetch from all seeds.
-    for seed in seeds {
+    for seed in seeds.connected() {
         let spinner = term::spinner(format!(
             "Fetching {} from {}..",
             term::format::tertiary(id),
-            term::format::tertiary(term::format::node(&seed))
+            term::format::tertiary(term::format::node(seed))
         ));
 
         // TODO: If none of them succeeds, output an error. Otherwise tell the caller
         // how many succeeded.
-        match node.fetch(id, seed)? {
+        match node.fetch(id, *seed)? {
             FetchResult::Success { .. } => {
                 spinner.finish();
             }

--- a/radicle-node/src/runtime/handle.rs
+++ b/radicle-node/src/runtime/handle.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crossbeam_channel as chan;
 use cyphernet::Ecdh;
+use radicle::node::Seeds;
 use thiserror::Error;
 
 use crate::crypto::Signer;
@@ -118,7 +119,7 @@ impl<G: Signer + Ecdh + 'static> radicle::node::Handle for Handle<G> {
         Ok(())
     }
 
-    fn seeds(&mut self, id: Id) -> Result<Vec<NodeId>, Self::Error> {
+    fn seeds(&mut self, id: Id) -> Result<Seeds, Self::Error> {
         let (sender, receiver) = chan::bounded(1);
         self.command(service::Command::Seeds(id, sender))?;
         receiver.recv().map_err(Error::from)

--- a/radicle-node/src/service/session.rs
+++ b/radicle-node/src/service/session.rs
@@ -186,6 +186,16 @@ impl Session {
         matches!(self.state, State::Connected { .. })
     }
 
+    pub fn is_fetching(&self) -> bool {
+        matches!(
+            self.state,
+            State::Connected {
+                protocol: Protocol::Fetch { .. },
+                ..
+            }
+        )
+    }
+
     pub fn is_disconnected(&self) -> bool {
         matches!(self.state, State::Disconnected { .. })
     }

--- a/radicle-node/src/test/handle.rs
+++ b/radicle-node/src/test/handle.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use crossbeam_channel as chan;
 
 use crate::identity::Id;
-use crate::node::FetchResult;
+use crate::node::{FetchResult, Seeds};
 use crate::runtime::HandleError;
 use crate::service;
 use crate::service::NodeId;
@@ -29,7 +29,7 @@ impl radicle::node::Handle for Handle {
         unimplemented!();
     }
 
-    fn seeds(&mut self, _id: Id) -> Result<Vec<NodeId>, Self::Error> {
+    fn seeds(&mut self, _id: Id) -> Result<Seeds, Self::Error> {
         unimplemented!();
     }
 

--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -159,7 +159,7 @@ fn test_replication() {
     assert!(tracked);
 
     let seeds = alice.handle.seeds(acme).unwrap();
-    assert!(seeds.contains(&bob.id));
+    assert!(seeds.is_connected(&bob.id));
 
     let result = alice.handle.fetch(acme, bob.id).unwrap();
     assert!(result.is_success());
@@ -213,7 +213,7 @@ fn test_clone() {
 
     let _ = alice.handle.track_repo(acme).unwrap();
     let seeds = alice.handle.seeds(acme).unwrap();
-    assert!(seeds.contains(&bob.id));
+    assert!(seeds.is_connected(&bob.id));
 
     let result = alice.handle.fetch(acme, bob.id).unwrap();
     assert!(result.is_success());


### PR DESCRIPTION
Previously, the seeds information would only consist of the connected NodeIds.

Improve on this by adding any disconnected and fetching seeds as well. A seed can either be disconnected, connected, or fetching -- where fetching implies connected.

To be able to see which NodeIds are being fetched from, it's necessary to add this information to the Session.

Fixes #343 