### PR TITLE
[Hold] radicle-httpd: basic blob streaming support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,9 +885,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1967,6 +1980,8 @@ dependencies = [
  "chrono",
  "fastrand",
  "flate2",
+ "futures-core",
+ "futures-util",
  "hyper",
  "lexopt",
  "nonempty 0.8.1",

--- a/radicle-httpd/Cargo.toml
+++ b/radicle-httpd/Cargo.toml
@@ -22,12 +22,14 @@ axum-server = { version = "0.4.4", default-features = false }
 chrono = { version = "0.4.22" }
 fastrand = { version = "1.7.0" }
 flate2 = { version = "1" }
+futures-core = { version = "0.3" }
 hyper = { version = "0.14.17", default-features = false }
 lexopt = { version = "0.2.1" }
 radicle-surf = { version = "0.9.0", default-features = false, features = ["serde"] }
 nonempty = { version = "0.8.1", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+tempfile = { version = "3.3.0" }
 thiserror = { version = "1" }
 time = { version = "0.3.17", features = ["parsing", "serde"] }
 tokio = { version = "1.21", default-features = false, features = ["macros", "rt-multi-thread"] }
@@ -41,6 +43,7 @@ path = "../radicle"
 version = "0.2.0"
 
 [dev-dependencies]
+futures-util = { version = "0.3" }
 hyper = { version = "0.14.17", default-features = false, features = ["client"] }
 pretty_assertions = { version = "1.3.0" }
 radicle-cli = { path = "../radicle-cli" }

--- a/radicle-httpd/src/raw.rs
+++ b/radicle-httpd/src/raw.rs
@@ -1,5 +1,12 @@
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use futures_core::Stream;
+use radicle_surf::blob::BlobRef;
+use std::fs::File;
+use std::io::{Read, Seek, Write};
 use std::sync::Arc;
 
+use axum::body::StreamBody;
 use axum::extract::State;
 use axum::http::header;
 use axum::response::IntoResponse;
@@ -10,7 +17,7 @@ use hyper::HeaderMap;
 use radicle::prelude::Id;
 use radicle::profile::Profile;
 use radicle::storage::git::paths;
-use radicle_surf::{Oid, Repository};
+use radicle_surf::{blob::Blob, Oid, Repository};
 
 use crate::axum_extra::Path;
 use crate::error::Error;
@@ -32,13 +39,93 @@ async fn file_handler(
     let mut response_headers = HeaderMap::new();
     response_headers.insert(header::CONTENT_TYPE, "text; charset=utf-8".parse().unwrap());
 
-    Ok::<_, Error>((response_headers, blob.content().to_owned()))
+    let response_body = blob_body(blob)?;
+    Ok::<_, Error>((response_headers, StreamBody::new(response_body)))
+}
+
+/// An enum to support both one-shot Vec and streaming.
+pub(crate) enum BlobBody {
+    Bytes(Vec<u8>),
+    Stream(FileStream),
+}
+
+impl Stream for BlobBody {
+    type Item = std::io::Result<Vec<u8>>;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let me = Pin::into_inner(self);
+
+        match me {
+            BlobBody::Bytes(v) => {
+                if v.is_empty() {
+                    Poll::Ready(None)
+                } else {
+                    let drain: Vec<_> = v.drain(..).collect();
+                    Poll::Ready(Some(Ok(drain)))
+                }
+            }
+            BlobBody::Stream(s) => {
+                let mut buf = vec![0u8; s.chunk_sz];
+                match s.file.read(&mut buf) {
+                    Ok(sz) => {
+                        if sz > 0 {
+                            buf.truncate(sz);
+                            Poll::Ready(Some(Ok(buf)))
+                        } else {
+                            Poll::Ready(None)
+                        }
+                    }
+                    Err(e) => Poll::Ready(Some(Err(e))),
+                }
+            }
+        }
+    }
+}
+
+const BLOB_STREAM_MIN_BYTES: usize = 4096000;
+const BLOB_STREAM_CHUNK_SIZE: usize = 4096;
+
+/// Creates a `BlobBody` that supports streaming.
+fn blob_body(blob: Blob<BlobRef>) -> Result<BlobBody, Error> {
+    if blob.size() < BLOB_STREAM_MIN_BYTES {
+        Ok(BlobBody::Bytes(blob.content().to_owned()))
+    } else {
+        let stream = file_stream(blob.content(), BLOB_STREAM_CHUNK_SIZE)?;
+        Ok(BlobBody::Stream(stream))
+    }
+}
+
+/// Creates a [`FileStream`] from `blob` backed by a tmp file.
+///
+/// `blob` can be freed after this function. The backing tmp file will be
+/// deleted automatically after the returned `FileStream` is dropped.
+pub(crate) fn file_stream(blob: &[u8], chunk_sz: usize) -> Result<FileStream, Error> {
+    let mut file = tempfile::tempfile()?;
+    file.write_all(blob)?;
+    file.rewind()?;
+
+    Ok(FileStream::new(file, chunk_sz))
+}
+
+/// Represents a read stream of a file.
+pub(crate) struct FileStream {
+    file: File,
+    chunk_sz: usize,
+}
+
+impl FileStream {
+    /// Creates a read stream of a file.
+    pub fn new(file: File, chunk_sz: usize) -> Self {
+        Self { file, chunk_sz }
+    }
 }
 
 #[cfg(test)]
 mod routes {
     use axum::http::StatusCode;
+    use futures_util::StreamExt;
 
+    use crate::raw::{file_stream, BlobBody};
     use crate::test::{self, get, HEAD};
 
     #[tokio::test]
@@ -55,5 +142,40 @@ mod routes {
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.body().await, "Hello World from dir1!\n");
+    }
+
+    #[tokio::test]
+    async fn test_blob_body() {
+        let blob = "This is a test blob"; // 19 chars.
+        let chunk_size = 10;
+
+        // Create a file stream and verify the first chunk.
+        let file_stream = file_stream(blob.as_bytes(), chunk_size).unwrap();
+        let mut file_body = BlobBody::Stream(file_stream);
+        let first_chunk = file_body.next().await.unwrap();
+        assert!(first_chunk.is_ok());
+        let first_chunk = first_chunk.unwrap();
+        assert_eq!(first_chunk.len(), chunk_size);
+
+        // Verify the second chunk.
+        let second_chunk = file_body.next().await.unwrap();
+        assert!(second_chunk.is_ok());
+        let second_chunk = second_chunk.unwrap();
+        assert_eq!(second_chunk.len(), 9);
+
+        // Verify no more chunks.
+        let third_chunk = file_body.next().await;
+        assert!(third_chunk.is_none());
+
+        // Create an one-shot Vec for `BlobBody` and verify the first chunk.
+        let mut blob_body = BlobBody::Bytes(blob.as_bytes().to_vec());
+        let first_chunk = blob_body.next().await.unwrap();
+        assert!(first_chunk.is_ok());
+        let first_chunk = first_chunk.unwrap();
+        assert_eq!(first_chunk.len(), 19); // all chars in one-shot.
+
+        // Verify no more chunks.
+        let second_chunk = blob_body.next().await;
+        assert!(second_chunk.is_none());
     }
 }


### PR DESCRIPTION
This is to implement a basic blob streaming support mentioned in [this discussion](https://github.com/radicle-dev/heartwood/pull/331#discussion_r1110054271).

As `radicle-surf` does not concern itself with IO, nor async, I think it is better to support streaming in `heartwood` for blobs. @xphoniex .

Update:  after rebasing to #331 , I've updated `file_handler` to show the use of the streaming support.  See `BlobBody` in the patch.