### PR TITLE
node: improve fetch

### DIFF
--- a/radicle-cli/examples/rad-node.md
+++ b/radicle-cli/examples/rad-node.md
@@ -48,9 +48,9 @@ repository that was already created:
 
 ```
 $ rad node tracking
-RID                               Scope Policy
----                               ----- ------
-rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji all   track
+RID                               Scope   Policy
+---                               -----   ------
+rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji trusted track
 ```
 
 This is the same as using the `--repos` flag, but if we wish to see

--- a/radicle-cli/src/commands/clone.rs
+++ b/radicle-cli/src/commands/clone.rs
@@ -10,6 +10,7 @@ use radicle::git::raw;
 use radicle::identity::doc::{DocError, Id};
 use radicle::identity::{doc, IdentityError};
 use radicle::node;
+use radicle::node::tracking::Scope;
 use radicle::node::{Handle as _, Node};
 use radicle::prelude::*;
 use radicle::rad;
@@ -169,7 +170,7 @@ pub fn clone<G: Signer>(
     let me = *signer.public_key();
 
     // Track.
-    if node.track_repo(id)? {
+    if node.track_repo(id, Scope::default())? {
         term::success!(
             "Tracking relationship established for {}",
             term::format::tertiary(id)

--- a/radicle-cli/src/commands/init.rs
+++ b/radicle-cli/src/commands/init.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, bail, Context as _};
 
 use radicle::crypto::ssh;
 use radicle::git::RefString;
+use radicle::node::tracking::Scope;
 use radicle::node::{Handle, NodeId};
 
 use crate::git;
@@ -220,7 +221,7 @@ pub fn init(options: Options, profile: &profile::Profile) -> anyhow::Result<()> 
             if options.track && node.is_running() {
                 // It's important to track our own repositories to make sure that our node signals
                 // interest for them. This ensures that messages relating to them are relayed to us.
-                node.track_repo(id)?;
+                node.track_repo(id, Scope::default())?;
             }
 
             spinner.message(format!(

--- a/radicle-cli/src/commands/node/tracking.rs
+++ b/radicle-cli/src/commands/node/tracking.rs
@@ -36,10 +36,9 @@ fn print_nodes(node: &Node) -> anyhow::Result<()> {
     for tracking::Node { id, alias, policy } in node.tracked_nodes()? {
         t.push([
             term::format::highlight(Did::from(id).to_string()),
-            if alias.is_empty() {
-                term::format::secondary("n/a".to_string())
-            } else {
-                term::format::secondary(alias)
+            match alias {
+                None => term::format::secondary("n/a".to_string()),
+                Some(alias) => term::format::secondary(alias),
             },
             term::format::secondary(policy.to_string()),
         ]);

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -11,7 +11,7 @@ use radicle::storage::{ReadRepository, ReadStorage};
 use radicle::test::fixtures;
 
 use radicle_cli_test::TestFormula;
-use radicle_node::service::tracking::Policy;
+use radicle_node::service::tracking::{Policy, Scope};
 use radicle_node::test::{
     environment::{Config, Environment},
     logger,
@@ -444,6 +444,7 @@ fn test_replication_via_seed() {
     let mut bob = bob.spawn(Config::default());
     let seed = seed.spawn(Config {
         policy: Policy::Track,
+        scope: Scope::All,
         ..Config::default()
     });
 

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -476,6 +476,10 @@ fn test_replication_via_seed() {
         )
         .unwrap();
 
+    alice
+        .rad("track", &[&bob.id.to_human()], working.join("alice"))
+        .unwrap();
+
     alice.routes_to(&[(rid, alice.id), (rid, seed.id)]);
     seed.routes_to(&[(rid, alice.id), (rid, seed.id)]);
     bob.routes_to(&[(rid, alice.id), (rid, seed.id)]);

--- a/radicle-node/src/control.rs
+++ b/radicle-node/src/control.rs
@@ -108,9 +108,9 @@ fn command<H: Handle<Error = runtime::HandleError>>(
             json::to_writer(writer, &seeds)?;
         }
         CommandName::TrackRepo => {
-            let rid: Id = parse::arg(cmd)?;
+            let (rid, scope) = parse::args(cmd)?;
 
-            match handle.track_repo(rid) {
+            match handle.track_repo(rid, scope) {
                 Ok(updated) => {
                     CommandResult::Okay { updated }.to_writer(writer)?;
                 }
@@ -294,6 +294,7 @@ mod tests {
     use crate::identity::Id;
     use crate::node::Handle;
     use crate::node::{Node, NodeId};
+    use crate::service::tracking::Scope;
     use crate::test;
 
     #[test]
@@ -352,8 +353,8 @@ mod tests {
         // Wait for node to be online.
         while !handle.is_running() {}
 
-        assert!(handle.track_repo(proj).unwrap());
-        assert!(!handle.track_repo(proj).unwrap());
+        assert!(handle.track_repo(proj, Scope::default()).unwrap());
+        assert!(!handle.track_repo(proj, Scope::default()).unwrap());
         assert!(handle.untrack_repo(proj).unwrap());
         assert!(!handle.untrack_repo(proj).unwrap());
 

--- a/radicle-node/src/runtime.rs
+++ b/radicle-node/src/runtime.rs
@@ -156,6 +156,7 @@ impl<G: Signer + Ecdh + 'static> Runtime<G> {
         }
 
         let pool = worker::Pool::with(
+            id,
             worker_recv,
             handle.clone(),
             worker::Config {

--- a/radicle-node/src/runtime.rs
+++ b/radicle-node/src/runtime.rs
@@ -116,7 +116,7 @@ impl<G: Signer + Ecdh + 'static> Runtime<G> {
 
         log::info!(target: "node", "Opening tracking policy table {}..", tracking_db.display());
         let tracking = tracking::Store::open(tracking_db)?;
-        let tracking = tracking::Config::new(config.policy, tracking);
+        let tracking = tracking::Config::new(config.policy, config.scope, tracking);
 
         log::info!(target: "node", "Default tracking policy set to '{}'", &config.policy);
         log::info!(target: "node", "Initializing service ({:?})..", network);

--- a/radicle-node/src/runtime/handle.rs
+++ b/radicle-node/src/runtime/handle.rs
@@ -182,9 +182,9 @@ impl<G: Signer + Ecdh + 'static> radicle::node::Handle for Handle<G> {
         receiver.recv().map_err(Error::from)
     }
 
-    fn track_repo(&mut self, id: Id) -> Result<bool, Error> {
+    fn track_repo(&mut self, id: Id, scope: tracking::Scope) -> Result<bool, Error> {
         let (sender, receiver) = chan::bounded(1);
-        self.command(service::Command::TrackRepo(id, sender))?;
+        self.command(service::Command::TrackRepo(id, scope, sender))?;
         receiver.recv().map_err(Error::from)
     }
 

--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -116,7 +116,7 @@ pub enum Command {
     /// Fetch the given repository from the network.
     Fetch(Id, NodeId, chan::Sender<FetchResult>),
     /// Track the given repository.
-    TrackRepo(Id, chan::Sender<bool>),
+    TrackRepo(Id, tracking::Scope, chan::Sender<bool>),
     /// Untrack the given repository.
     UntrackRepo(Id, chan::Sender<bool>),
     /// Track the given node.
@@ -136,7 +136,7 @@ impl fmt::Debug for Command {
             Self::Connect(id, addr) => write!(f, "Connect({id}, {addr})"),
             Self::Seeds(id, _) => write!(f, "Seeds({id})"),
             Self::Fetch(id, node, _) => write!(f, "Fetch({id}, {node})"),
-            Self::TrackRepo(id, _) => write!(f, "TrackRepo({id})"),
+            Self::TrackRepo(id, scope, _) => write!(f, "TrackRepo({id}, {scope})"),
             Self::UntrackRepo(id, _) => write!(f, "UntrackRepo({id})"),
             Self::TrackNode(id, _, _) => write!(f, "TrackNode({id})"),
             Self::UntrackNode(id, _) => write!(f, "UntrackNode({id})"),
@@ -491,9 +491,9 @@ where
                 self.fetch_reqs.insert(rid, resp);
                 self.fetch(rid, &seed);
             }
-            Command::TrackRepo(rid, resp) => {
+            Command::TrackRepo(rid, scope, resp) => {
                 let tracked = self
-                    .track_repo(&rid, tracking::Scope::All)
+                    .track_repo(&rid, scope)
                     .expect("Service::command: error tracking repository");
                 // TODO: Try to fetch project if we weren't tracking it before.
                 resp.send(tracked).ok();

--- a/radicle-node/src/service/config.rs
+++ b/radicle-node/src/service/config.rs
@@ -2,7 +2,7 @@ use localtime::LocalDuration;
 
 use radicle::node::Address;
 
-use crate::service::tracking::Policy;
+use crate::service::tracking::{Policy, Scope};
 use crate::service::NodeId;
 
 /// Peer-to-peer network.
@@ -47,6 +47,8 @@ pub struct Config {
     pub limits: Limits,
     /// Default tracking policy.
     pub policy: Policy,
+    /// Default tracking scope.
+    pub scope: Scope,
 }
 
 impl Default for Config {
@@ -58,6 +60,7 @@ impl Default for Config {
             relay: true,
             limits: Limits::default(),
             policy: Policy::default(),
+            scope: Scope::default(),
         }
     }
 }

--- a/radicle-node/src/service/session.rs
+++ b/radicle-node/src/service/session.rs
@@ -108,6 +108,8 @@ pub enum Error {
     Timeout,
     #[error("handshake error")]
     Handshake(String),
+    #[error("failed to inspect remotes for fetch: {0}")]
+    Remotes(#[from] storage::refs::Error),
 }
 
 /// A peer session. Each connected peer will have one session.

--- a/radicle-node/src/service/tracking.rs
+++ b/radicle-node/src/service/tracking.rs
@@ -15,7 +15,6 @@ pub use store::Error;
 pub struct Config {
     /// Default policy, if a policy for a specific node or repository was not found.
     policy: Policy,
-    #[allow(dead_code)]
     /// Default scope, if a scope for a specific repository was not found.
     scope: Scope,
     /// Underlying configuration store.
@@ -34,30 +33,34 @@ impl Config {
 
     /// Check if a repository is tracked.
     pub fn is_repo_tracked(&self, id: &Id) -> Result<bool, Error> {
-        self.repo_policy(id).map(|entry| entry == Policy::Track)
+        self.repo_policy(id)
+            .map(|entry| entry.policy == Policy::Track)
     }
 
     /// Check if a node is tracked.
     pub fn is_node_tracked(&self, id: &NodeId) -> Result<bool, Error> {
-        self.node_policy(id).map(|entry| entry == Policy::Track)
+        self.node_policy(id)
+            .map(|entry| entry.policy == Policy::Track)
     }
 
     /// Get a node's tracking information.
     /// Returns the default policy if the node isn't found.
-    pub fn node_policy(&self, id: &NodeId) -> Result<Policy, Error> {
-        if let Some((_, policy)) = self.store.node_entry(id)? {
-            return Ok(policy);
-        }
-        Ok(self.policy)
+    pub fn node_policy(&self, id: &NodeId) -> Result<Node, Error> {
+        Ok(self.store.node_entry(id)?.unwrap_or(Node {
+            id: *id,
+            alias: None,
+            policy: self.policy,
+        }))
     }
 
     /// Get a repository's tracking information.
     /// Returns the default policy if the repo isn't found.
-    pub fn repo_policy(&self, id: &Id) -> Result<Policy, Error> {
-        if let Some((_, policy)) = self.store.repo_entry(id)? {
-            return Ok(policy);
-        }
-        Ok(self.policy)
+    pub fn repo_policy(&self, id: &Id) -> Result<Repo, Error> {
+        Ok(self.store.repo_entry(id)?.unwrap_or(Repo {
+            id: *id,
+            scope: self.scope,
+            policy: self.policy,
+        }))
     }
 }
 

--- a/radicle-node/src/service/tracking.rs
+++ b/radicle-node/src/service/tracking.rs
@@ -14,25 +14,32 @@ pub use store::Error;
 #[derive(Debug)]
 pub struct Config {
     /// Default policy, if a policy for a specific node or repository was not found.
-    default: Policy,
+    policy: Policy,
+    #[allow(dead_code)]
+    /// Default scope, if a scope for a specific repository was not found.
+    scope: Scope,
     /// Underlying configuration store.
     store: store::Config,
 }
 
 impl Config {
     /// Create a new tracking configuration.
-    pub fn new(default: Policy, store: store::Config) -> Self {
-        Self { default, store }
+    pub fn new(policy: Policy, scope: Scope, store: store::Config) -> Self {
+        Self {
+            policy,
+            scope,
+            store,
+        }
     }
 
     /// Check if a repository is tracked.
     pub fn is_repo_tracked(&self, id: &Id) -> Result<bool, Error> {
-        self.repo_policy(id).map(|policy| policy == Policy::Track)
+        self.repo_policy(id).map(|entry| entry == Policy::Track)
     }
 
     /// Check if a node is tracked.
     pub fn is_node_tracked(&self, id: &NodeId) -> Result<bool, Error> {
-        self.node_policy(id).map(|policy| policy == Policy::Track)
+        self.node_policy(id).map(|entry| entry == Policy::Track)
     }
 
     /// Get a node's tracking information.
@@ -41,7 +48,7 @@ impl Config {
         if let Some((_, policy)) = self.store.node_entry(id)? {
             return Ok(policy);
         }
-        Ok(self.default)
+        Ok(self.policy)
     }
 
     /// Get a repository's tracking information.
@@ -50,7 +57,7 @@ impl Config {
         if let Some((_, policy)) = self.store.repo_entry(id)? {
             return Ok(policy);
         }
-        Ok(self.default)
+        Ok(self.policy)
     }
 }
 

--- a/radicle-node/src/service/tracking/store.rs
+++ b/radicle-node/src/service/tracking/store.rs
@@ -309,8 +309,8 @@ mod test {
 
         assert!(db.track_repo(&id, Scope::All).unwrap());
         assert_eq!(db.repo_entry(&id).unwrap().unwrap().0, Scope::All);
-        assert!(db.track_repo(&id, Scope::DelegatesOnly).unwrap());
-        assert_eq!(db.repo_entry(&id).unwrap().unwrap().0, Scope::DelegatesOnly);
+        assert!(db.track_repo(&id, Scope::Trusted).unwrap());
+        assert_eq!(db.repo_entry(&id).unwrap().unwrap().0, Scope::Trusted);
     }
 
     #[test]

--- a/radicle-node/src/test/environment.rs
+++ b/radicle-node/src/test/environment.rs
@@ -9,6 +9,8 @@ use std::{
 
 use crossbeam_channel as chan;
 
+use radicle::cob;
+use radicle::cob::issue;
 use radicle::crypto::ssh::{keystore::MemorySigner, Keystore};
 use radicle::crypto::test::signer::MockSigner;
 use radicle::crypto::{KeyPair, Seed, Signer};
@@ -19,7 +21,7 @@ use radicle::node::Handle as _;
 use radicle::profile::Home;
 use radicle::profile::Profile;
 use radicle::rad;
-use radicle::storage::ReadStorage;
+use radicle::storage::ReadStorage as _;
 use radicle::test::fixtures;
 use radicle::Storage;
 
@@ -233,6 +235,16 @@ impl<G: Signer + cyphernet::Ecdh> NodeHandle<G> {
             return Err(io::ErrorKind::Other.into());
         }
         Ok(())
+    }
+
+    /// Create an [`issue::Issue`] in the `NodeHandle`'s storage.
+    pub fn issue(&self, rid: Id, title: &str, desc: &str) -> cob::ObjectId {
+        let repo = self.storage.repository(rid).unwrap();
+        let mut issues = issue::Issues::open(&repo).unwrap();
+        *issues
+            .create(title, desc, &[], &[], &self.signer)
+            .unwrap()
+            .id()
     }
 }
 

--- a/radicle-node/src/test/handle.rs
+++ b/radicle-node/src/test/handle.rs
@@ -60,7 +60,7 @@ impl radicle::node::Handle for Handle {
             .copied()
             .map(|id| tracking::Node {
                 id,
-                alias: "".to_string(),
+                alias: None,
                 policy: tracking::Policy::Track,
             })
             .collect())

--- a/radicle-node/src/test/handle.rs
+++ b/radicle-node/src/test/handle.rs
@@ -66,7 +66,7 @@ impl radicle::node::Handle for Handle {
             .collect())
     }
 
-    fn track_repo(&mut self, id: Id) -> Result<bool, Self::Error> {
+    fn track_repo(&mut self, id: Id, _scope: tracking::Scope) -> Result<bool, Self::Error> {
         Ok(self.tracking_repos.insert(id))
     }
 

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -75,7 +75,15 @@ impl<S, G> DerefMut for Peer<S, G> {
 
 impl Peer<MockStorage, MockSigner> {
     pub fn new(name: &'static str, ip: impl Into<net::IpAddr>) -> Self {
-        Self::config(name, ip, MockStorage::empty(), Config::default())
+        Self::with_storage(name, ip, MockStorage::empty())
+    }
+
+    pub fn with_storage(
+        name: &'static str,
+        ip: impl Into<net::IpAddr>,
+        storage: MockStorage,
+    ) -> Self {
+        Self::config(name, ip, storage, Config::default())
     }
 }
 

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -106,7 +106,7 @@ impl Default for Config<MockSigner> {
             config: service::Config::default(),
             addrs: address::Book::memory().unwrap(),
             local_time: LocalTime::now(),
-            policy: Policy::Block,
+            policy: Policy::default(),
             scope: Scope::default(),
             signer,
             rng,

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -16,7 +16,7 @@ use crate::prelude::*;
 use crate::service;
 use crate::service::message::*;
 use crate::service::reactor::Io;
-use crate::service::tracking::Policy;
+use crate::service::tracking::{Policy, Scope};
 use crate::service::*;
 use crate::storage::git::transport::remote;
 use crate::storage::{RemoteId, WriteStorage};
@@ -92,6 +92,7 @@ pub struct Config<G: Signer + 'static> {
     pub addrs: address::Book,
     pub local_time: LocalTime,
     pub policy: Policy,
+    pub scope: Scope,
     pub signer: G,
     pub rng: fastrand::Rng,
 }
@@ -106,6 +107,7 @@ impl Default for Config<MockSigner> {
             addrs: address::Book::memory().unwrap(),
             local_time: LocalTime::now(),
             policy: Policy::Block,
+            scope: Scope::default(),
             signer,
             rng,
         }
@@ -125,7 +127,7 @@ where
     ) -> Self {
         let routing = routing::Table::memory().unwrap();
         let tracking = tracking::Store::memory().unwrap();
-        let tracking = tracking::Config::new(config.policy, tracking);
+        let tracking = tracking::Config::new(config.policy, config.scope, tracking);
         let id = *config.signer.public_key();
         let service = Service::new(
             config.config,

--- a/radicle-node/src/test/simulator.rs
+++ b/radicle-node/src/test/simulator.rs
@@ -679,6 +679,7 @@ fn fetch<W: WriteRepository>(
     let namespace = match namespaces.into() {
         Namespaces::All => None,
         Namespaces::One(ns) => Some(ns),
+        Namespaces::Many(ns) => Some(ns.head),
     };
     let mut updates = Vec::new();
     let mut callbacks = git::RemoteCallbacks::new();

--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -345,7 +345,11 @@ fn test_tracking() {
     let proj_id: identity::Id = test::arbitrary::gen(1);
 
     let (sender, receiver) = chan::bounded(1);
-    alice.command(Command::TrackRepo(proj_id, sender));
+    alice.command(Command::TrackRepo(
+        proj_id,
+        tracking::Scope::default(),
+        sender,
+    ));
     let policy_change = receiver.recv().map_err(runtime::HandleError::from).unwrap();
     assert!(policy_change);
     assert!(alice.tracking().is_repo_tracked(&proj_id).unwrap());
@@ -927,7 +931,7 @@ fn test_track_repo_subscribe() {
     let (send, recv) = chan::bounded(1);
 
     alice.connect_to(&bob);
-    alice.command(Command::TrackRepo(rid, send));
+    alice.command(Command::TrackRepo(rid, tracking::Scope::default(), send));
     assert!(recv.recv().unwrap());
 
     assert_matches!(
@@ -981,11 +985,19 @@ fn test_push_and_pull() {
 
     // Bob tracks Alice's project.
     let (sender, _) = chan::bounded(1);
-    bob.command(service::Command::TrackRepo(proj_id, sender));
+    bob.command(service::Command::TrackRepo(
+        proj_id,
+        tracking::Scope::default(),
+        sender,
+    ));
 
     // Eve tracks Alice's project.
     let (sender, _) = chan::bounded(1);
-    eve.command(service::Command::TrackRepo(proj_id, sender));
+    eve.command(service::Command::TrackRepo(
+        proj_id,
+        tracking::Scope::default(),
+        sender,
+    ));
 
     let mut sim = Simulation::new(
         LocalTime::now(),

--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -581,7 +581,9 @@ fn test_refs_announcement_relay() {
 
 #[test]
 fn test_refs_announcement_no_subscribe() {
-    let mut alice = Peer::new("alice", [7, 7, 7, 7]);
+    let storage = arbitrary::nonempty_storage(1);
+    let rid = *storage.inventory.keys().next().unwrap();
+    let mut alice = Peer::with_storage("alice", [7, 7, 7, 7], storage);
     let bob = Peer::new("bob", [8, 8, 8, 8]);
     let eve = Peer::new("eve", [9, 9, 9, 9]);
     let id = arbitrary::gen(1);
@@ -589,18 +591,19 @@ fn test_refs_announcement_no_subscribe() {
     alice.track_repo(&id, tracking::Scope::All).unwrap();
     alice.connect_to(&bob);
     alice.connect_to(&eve);
-    alice.receive(bob.id(), bob.refs_announcement(id));
+    alice.receive(bob.id(), bob.refs_announcement(rid));
 
     assert!(alice.messages(eve.id()).next().is_none());
 }
 
 #[test]
 fn test_gossip_during_fetch() {
-    let mut alice = Peer::new("alice", [7, 7, 7, 7]);
+    let storage = arbitrary::nonempty_storage(1);
+    let rid = *storage.inventory.keys().next().unwrap();
+    let mut alice = Peer::with_storage("alice", [7, 7, 7, 7], storage);
     let bob = Peer::new("bob", [8, 8, 8, 8]);
     let eve = Peer::new("eve", [9, 9, 9, 9]);
     let now = LocalTime::now().as_millis();
-    let rid = arbitrary::gen::<Id>(1);
     let (send, _recv) = chan::bounded::<node::FetchResult>(1);
     let inventory1 = BoundedVec::try_from(arbitrary::vec(1)).unwrap();
     let inventory2 = BoundedVec::try_from(arbitrary::vec(1)).unwrap();

--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -6,6 +6,7 @@ use radicle::storage::{ReadRepository, ReadStorage};
 use radicle::{assert_matches, rad};
 
 use crate::service;
+use crate::service::tracking::Scope;
 use crate::storage::git::transport;
 use crate::test::environment::{converge, Node};
 use crate::test::logger;
@@ -155,7 +156,7 @@ fn test_replication() {
     let inventory = alice.handle.inventory().unwrap();
     assert!(inventory.try_iter().next().is_none());
 
-    let tracked = alice.handle.track_repo(acme).unwrap();
+    let tracked = alice.handle.track_repo(acme, Scope::All).unwrap();
     assert!(tracked);
 
     let seeds = alice.handle.seeds(acme).unwrap();
@@ -211,7 +212,7 @@ fn test_clone() {
 
     transport::local::register(alice.storage.clone());
 
-    let _ = alice.handle.track_repo(acme).unwrap();
+    let _ = alice.handle.track_repo(acme, Scope::All).unwrap();
     let seeds = alice.handle.seeds(acme).unwrap();
     assert!(seeds.is_connected(&bob.id));
 
@@ -261,7 +262,7 @@ fn test_fetch_up_to_date() {
 
     transport::local::register(alice.storage.clone());
 
-    let _ = alice.handle.track_repo(acme).unwrap();
+    let _ = alice.handle.track_repo(acme, Scope::All).unwrap();
     let result = alice.handle.fetch(acme, bob.id).unwrap();
     assert!(result.is_success());
 

--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -196,6 +196,33 @@ fn test_replication() {
 }
 
 #[test]
+fn test_dont_fetch_owned_refs() {
+    logger::init(log::Level::Debug);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mut alice = Node::init(tmp.path());
+    let bob = Node::init(tmp.path());
+    let acme = alice.project("acme", "");
+
+    let mut alice = alice.spawn(service::Config::default());
+    let mut bob = bob.spawn(service::Config::default());
+
+    alice.connect(&bob);
+    converge([&alice, &bob]);
+
+    assert!(bob.handle.track_repo(acme, Scope::Trusted).unwrap());
+
+    let result = bob.handle.fetch(acme, alice.id).unwrap();
+    assert!(result.is_success());
+
+    log::debug!(target: "test", "Fetch complete with {}", bob.id);
+
+    alice.issue(acme, "Don't fetch self", "Use ^");
+    let result = alice.handle.fetch(acme, bob.id).unwrap();
+    assert!(result.is_success())
+}
+
+#[test]
 #[ignore = "failing"]
 fn test_fetch_trusted_remotes() {
     logger::init(log::Level::Debug);

--- a/radicle/src/identity/doc.rs
+++ b/radicle/src/identity/doc.rs
@@ -299,6 +299,16 @@ impl Doc<Verified> {
 
         Ok(oid.into())
     }
+
+    #[cfg(any(test, feature = "test"))]
+    pub(crate) fn unverified(self) -> Doc<Unverified> {
+        Doc {
+            payload: self.payload,
+            delegates: self.delegates,
+            threshold: self.threshold,
+            verified: PhantomData,
+        }
+    }
 }
 
 impl Doc<Unverified> {

--- a/radicle/src/node.rs
+++ b/radicle/src/node.rs
@@ -393,7 +393,7 @@ pub trait Handle {
     fn fetch(&mut self, id: Id, from: NodeId) -> Result<FetchResult, Self::Error>;
     /// Start tracking the given project. Doesn't do anything if the project is already
     /// tracked.
-    fn track_repo(&mut self, id: Id) -> Result<bool, Self::Error>;
+    fn track_repo(&mut self, id: Id, scope: tracking::Scope) -> Result<bool, Self::Error>;
     /// Start tracking the given node.
     fn track_node(&mut self, id: NodeId, alias: Option<String>) -> Result<bool, Self::Error>;
     /// Untrack the given project and delete it from storage.
@@ -544,8 +544,8 @@ impl Handle for Node {
         response.into()
     }
 
-    fn track_repo(&mut self, id: Id) -> Result<bool, Error> {
-        let mut line = self.call(CommandName::TrackRepo, [id.urn()])?;
+    fn track_repo(&mut self, id: Id, scope: tracking::Scope) -> Result<bool, Error> {
+        let mut line = self.call(CommandName::TrackRepo, [id.urn(), scope.to_string()])?;
         let response: CommandResult = line.next().ok_or(Error::EmptyResponse {
             cmd: CommandName::TrackRepo,
         })??;

--- a/radicle/src/node/tracking.rs
+++ b/radicle/src/node/tracking.rs
@@ -94,8 +94,6 @@ impl TryFrom<&sqlite::Value> for Policy {
 pub enum Scope {
     /// Track remotes of nodes that are already tracked.
     Trusted,
-    /// Track remotes of repository delegates.
-    DelegatesOnly,
     /// Track all remotes.
     All,
 }
@@ -104,7 +102,6 @@ impl fmt::Display for Scope {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Scope::Trusted => f.write_str("trusted"),
-            Scope::DelegatesOnly => f.write_str("delegates-only"),
             Scope::All => f.write_str("all"),
         }
     }
@@ -120,7 +117,6 @@ impl FromStr for Scope {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "trusted" => Ok(Self::Trusted),
-            "delegates-only" => Ok(Self::DelegatesOnly),
             "all" => Ok(Self::All),
             _ => Err(ParseScopeError(s.to_string())),
         }
@@ -136,7 +132,6 @@ impl sqlite::BindableWithIndex for Scope {
     ) -> sqlite::Result<()> {
         let s = match self {
             Self::Trusted => "trusted",
-            Self::DelegatesOnly => "delegates-only",
             Self::All => "all",
         };
         s.bind(stmt, i)

--- a/radicle/src/node/tracking.rs
+++ b/radicle/src/node/tracking.rs
@@ -90,9 +90,10 @@ impl TryFrom<&sqlite::Value> for Policy {
 }
 
 /// Tracking scope of a repository tracking policy.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Scope {
     /// Track remotes of nodes that are already tracked.
+    #[default]
     Trusted,
     /// Track all remotes.
     All,

--- a/radicle/src/node/tracking.rs
+++ b/radicle/src/node/tracking.rs
@@ -18,7 +18,7 @@ pub struct Repo {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Node {
     pub id: NodeId,
-    pub alias: Alias,
+    pub alias: Option<Alias>,
     pub policy: Policy,
 }
 

--- a/radicle/src/storage.rs
+++ b/radicle/src/storage.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{fmt, io};
 
+use nonempty::NonEmpty;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -18,6 +19,7 @@ use crate::git::ext as git_ext;
 use crate::git::{Qualified, RefError, RefString};
 use crate::identity;
 use crate::identity::doc::DocError;
+use crate::identity::Did;
 use crate::identity::{Id, IdError, IdentityError};
 use crate::storage::refs::Refs;
 
@@ -355,6 +357,14 @@ pub trait ReadRepository {
 
     /// Get all remotes.
     fn remotes(&self) -> Result<Remotes<Verified>, refs::Error>;
+
+    /// Get repository delegates.
+    fn delegates(&self) -> Result<NonEmpty<Did>, IdentityError> {
+        let (_, doc) = self.identity_doc()?;
+        let doc = doc.verified()?;
+
+        Ok(doc.delegates)
+    }
 
     /// Get the repository's identity document.
     fn identity_doc(&self) -> Result<(Oid, identity::Doc<Unverified>), IdentityError>;

--- a/radicle/src/test/arbitrary.rs
+++ b/radicle/src/test/arbitrary.rs
@@ -58,6 +58,14 @@ pub fn vec<T: Eq + Arbitrary>(size: usize) -> Vec<T> {
     vec
 }
 
+pub fn nonempty_storage(size: usize) -> MockStorage {
+    let mut storage = gen::<MockStorage>(size);
+    storage
+        .inventory
+        .insert(gen::<Id>(size), gen::<Doc<Verified>>(size));
+    storage
+}
+
 pub fn gen<T: Arbitrary>(size: usize) -> T {
     let mut gen = qcheck::Gen::new(size);
 


### PR DESCRIPTION
The fetch implementation will potentially fetch the local operator's remote, which is unnecessary and could result in deleted data.

Fix this by threading the local operator's public key and add an ignore refspec to the fetch arguments, i.e.

    ^refs/namespaces/<local>/*

The implementation also strictly fetches all or one namespace. This is improved upon by introducing a new variant for specifying a set of namespaces.

Fixes #317 