### PR TITLE
radicle: remove FetchResult associated type

### DIFF
--- a/radicle-node/src/control.rs
+++ b/radicle-node/src/control.rs
@@ -13,7 +13,7 @@ use serde_json as json;
 
 use crate::identity::Id;
 use crate::node::NodeId;
-use crate::node::{Command, CommandName, CommandResult, FetchResult};
+use crate::node::{Command, CommandName, CommandResult};
 use crate::runtime;
 
 #[derive(thiserror::Error, Debug)]
@@ -25,7 +25,7 @@ pub enum Error {
 }
 
 /// Listen for commands on the control socket, and process them.
-pub fn listen<H: Handle<Error = runtime::HandleError, FetchResult = FetchResult>>(
+pub fn listen<H: Handle<Error = runtime::HandleError>>(
     listener: UnixListener,
     mut handle: H,
 ) -> Result<(), Error> {
@@ -74,7 +74,7 @@ enum CommandError {
     Shutdown,
 }
 
-fn command<H: Handle<Error = runtime::HandleError, FetchResult = FetchResult>>(
+fn command<H: Handle<Error = runtime::HandleError>>(
     stream: &UnixStream,
     handle: &mut H,
 ) -> Result<(), CommandError> {
@@ -199,7 +199,7 @@ fn command<H: Handle<Error = runtime::HandleError, FetchResult = FetchResult>>(
     Ok(())
 }
 
-fn fetch<W: Write, H: Handle<Error = runtime::HandleError, FetchResult = FetchResult>>(
+fn fetch<W: Write, H: Handle<Error = runtime::HandleError>>(
     id: Id,
     node: NodeId,
     mut writer: W,

--- a/radicle-node/src/runtime/handle.rs
+++ b/radicle-node/src/runtime/handle.rs
@@ -107,7 +107,6 @@ impl<G: Signer + Ecdh + 'static> Handle<G> {
 impl<G: Signer + Ecdh + 'static> radicle::node::Handle for Handle<G> {
     type Sessions = Sessions;
     type Error = Error;
-    type FetchResult = FetchResult;
 
     fn is_running(&self) -> bool {
         true

--- a/radicle-node/src/test/handle.rs
+++ b/radicle-node/src/test/handle.rs
@@ -20,7 +20,6 @@ pub struct Handle {
 impl radicle::node::Handle for Handle {
     type Error = HandleError;
     type Sessions = service::Sessions;
-    type FetchResult = FetchResult;
 
     fn is_running(&self) -> bool {
         true

--- a/radicle/src/node.rs
+++ b/radicle/src/node.rs
@@ -243,8 +243,6 @@ pub trait Handle {
     type Sessions;
     /// The error returned by all methods.
     type Error: std::error::Error + Send + Sync + 'static;
-    /// Result of a fetch.
-    type FetchResult;
 
     /// Check if the node is running. to a peer.
     fn is_running(&self) -> bool;
@@ -253,7 +251,7 @@ pub trait Handle {
     /// Lookup the seeds of a given repository in the routing table.
     fn seeds(&mut self, id: Id) -> Result<Vec<NodeId>, Self::Error>;
     /// Fetch a repository from the network.
-    fn fetch(&mut self, id: Id, from: NodeId) -> Result<Self::FetchResult, Self::Error>;
+    fn fetch(&mut self, id: Id, from: NodeId) -> Result<FetchResult, Self::Error>;
     /// Start tracking the given project. Doesn't do anything if the project is already
     /// tracked.
     fn track_repo(&mut self, id: Id) -> Result<bool, Self::Error>;
@@ -319,7 +317,6 @@ impl Node {
 impl Handle for Node {
     type Sessions = ();
     type Error = Error;
-    type FetchResult = FetchResult;
 
     fn is_running(&self) -> bool {
         let Ok(mut lines) = self.call::<&str, CommandResult>(CommandName::Status, []) else {
@@ -346,7 +343,7 @@ impl Handle for Node {
         Ok(seeds)
     }
 
-    fn fetch(&mut self, id: Id, from: NodeId) -> Result<Self::FetchResult, Error> {
+    fn fetch(&mut self, id: Id, from: NodeId) -> Result<FetchResult, Error> {
         let result = self
             .call(CommandName::Fetch, [id.urn(), from.to_human()])?
             .next()


### PR DESCRIPTION
The Handle trait defines a FetchResult associated type. This type is always instantiated to be the FetchResult enum in radicle::node.

Remove the associated type to simplify the trait.