### PR TITLE
httpd: Use `repo.identity_doc()` instead of `repo.identity_of(..)`

### DIFF
--- a/radicle-httpd/src/api.rs
+++ b/radicle-httpd/src/api.rs
@@ -48,7 +48,7 @@ impl Context {
         let storage = &self.profile.storage;
         let repo = storage.repository(id)?;
         let (_, head) = repo.head()?;
-        let doc = repo.identity_of(self.profile.id())?;
+        let doc = repo.identity_doc()?.1.verified()?;
         let payload = doc.project()?;
         let delegates = doc.delegates;
         let issues = Issues::open(self.profile.public_key, &repo)?.counts()?;

--- a/radicle-httpd/src/api/error.rs
+++ b/radicle-httpd/src/api/error.rs
@@ -61,6 +61,10 @@ pub enum Error {
     /// Storage refs error.
     #[error(transparent)]
     StorageRef(#[from] radicle::storage::refs::Error),
+
+    /// Identity doc error.
+    #[error(transparent)]
+    IdentityDoc(#[from] radicle::identity::doc::DocError),
 }
 
 impl IntoResponse for Error {

--- a/radicle-httpd/src/api/v1/delegates.rs
+++ b/radicle-httpd/src/api/v1/delegates.rs
@@ -40,7 +40,8 @@ async fn delegates_projects_handler(
         .filter_map(|id| {
             let Ok(repo) = storage.repository(id) else { return None };
             let Ok((_, head)) = repo.head() else { return None };
-            let Ok(doc) = repo.identity_of(ctx.profile.id()) else { return None };
+            let Ok((_, doc)) = repo.identity_doc() else { return None };
+            let Ok(doc) = doc.verified() else { return None };
             let Ok(payload) = doc.project() else { return None };
 
             let delegates = doc.delegates;

--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -79,7 +79,8 @@ async fn project_root_handler(
             let Ok(repo) = storage.repository(id) else { return None };
             let Ok((_, head)) = repo.head() else { return None };
             let Ok(payload) = repo.project_of(ctx.profile.id()) else { return None };
-            let Ok(doc) = repo.identity_of(ctx.profile.id()) else { return None };
+            let Ok((_, doc)) = repo.identity_doc() else { return None };
+            let Ok(doc) = doc.verified() else { return None };
             let Ok(issues) = Issues::open(ctx.profile.public_key, &repo) else { return None };
             let Ok(issues) = issues.counts() else { return None };
             let Ok(patches) = Patches::open(ctx.profile.public_key, &repo) else { return None };


### PR DESCRIPTION
related https://github.com/radicle-dev/heartwood/issues/295