### PR TITLE
radicle-httpd: sort cobs listing endpoints

### DIFF
--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -394,10 +394,10 @@ async fn issues_handler(
     let storage = &ctx.profile.storage;
     let repo = storage.repository(project)?;
     let issues = Issues::open(ctx.profile.public_key, &repo)?;
+    let mut issues: Vec<_> = issues.all()?.filter_map(|r| r.ok()).collect::<Vec<_>>();
+    issues.sort_by(|(_, a, _), (_, b, _)| b.timestamp().cmp(&a.timestamp()));
     let issues = issues
-        .all()?
         .into_iter()
-        .filter_map(|r| r.ok())
         .map(|(id, issue, _)| api::json::issue(id, issue))
         .skip(page * per_page)
         .take(per_page)
@@ -532,10 +532,10 @@ async fn patches_handler(
     let storage = &ctx.profile.storage;
     let repo = storage.repository(project)?;
     let patches = Patches::open(ctx.profile.public_key, &repo)?;
+    let mut patches = patches.all()?.filter_map(|r| r.ok()).collect::<Vec<_>>();
+    patches.sort_by(|(_, a, _), (_, b, _)| b.timestamp().cmp(&a.timestamp()));
     let patches = patches
-        .all()?
         .into_iter()
-        .filter_map(|r| r.ok())
         .map(|(id, patch, _)| api::json::patch(id, patch))
         .skip(page * per_page)
         .take(per_page)

--- a/radicle/src/cob/issue.rs
+++ b/radicle/src/cob/issue.rs
@@ -9,7 +9,7 @@ use radicle_crdt::clock;
 use radicle_crdt::{LWWReg, LWWSet, Max, Semilattice};
 
 use crate::cob;
-use crate::cob::common::{Author, Reaction, Tag};
+use crate::cob::common::{Author, Reaction, Tag, Timestamp};
 use crate::cob::store::FromHistory as _;
 use crate::cob::store::Transaction;
 use crate::cob::thread;
@@ -173,6 +173,15 @@ impl Issue {
 
     pub fn tags(&self) -> impl Iterator<Item = &Tag> {
         self.tags.iter()
+    }
+
+    pub fn timestamp(&self) -> Timestamp {
+        self.thread
+            .comments()
+            .next()
+            .map(|(_, c)| c)
+            .expect("Issue::timestamp: at least one comment is present")
+            .timestamp()
     }
 
     pub fn author(&self) -> Author {


### PR DESCRIPTION
As talked on zulip https://radicle.zulipchat.com/#narrow/stream/369277-heartwood/topic/cobs.20pagination

We need the issues and patches to be returned from `GET /projects/:project/issues` and `GET /projects/:project/patches` to be sorted before doing the pagination.
This will allow us to receive the same output every time we call the endpoint with the same params.