### PR TITLE
httpd: Change format of tracing messages

### DIFF
--- a/radicle-httpd/Cargo.toml
+++ b/radicle-httpd/Cargo.toml
@@ -24,8 +24,8 @@ fastrand = { version = "1.7.0" }
 flate2 = { version = "1" }
 hyper = { version = "0.14.17", default-features = false }
 lexopt = { version = "0.2.1" }
-radicle-surf = { version = "0.9.0", default-features = false, features = ["serde"] }
 nonempty = { version = "0.8.1", features = ["serialize"] }
+radicle-surf = { version = "0.9.0", default-features = false, features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = { version = "1" }
@@ -40,10 +40,12 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["s
 path = "../radicle"
 version = "0.2.0"
 
+[dependencies.radicle-cli]
+path = "../radicle-cli"
+
 [dev-dependencies]
 hyper = { version = "0.14.17", default-features = false, features = ["client"] }
 pretty_assertions = { version = "1.3.0" }
-radicle-cli = { path = "../radicle-cli" }
 radicle-crypto = { path = "../radicle-crypto" }
 tempfile = { version = "3.3.0" }
 tower = { version = "0.4", features = ["util"] }

--- a/radicle-httpd/src/main.rs
+++ b/radicle-httpd/src/main.rs
@@ -18,7 +18,9 @@ mod logger {
 #[cfg(not(feature = "logfmt"))]
 mod logger {
     pub fn subscriber() -> impl tracing::Subscriber {
-        tracing_subscriber::FmtSubscriber::new()
+        tracing_subscriber::FmtSubscriber::builder()
+            .with_target(false)
+            .finish()
     }
 }
 

--- a/radicle-httpd/src/tracing_extra.rs
+++ b/radicle-httpd/src/tracing_extra.rs
@@ -1,0 +1,68 @@
+use std::fmt;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::extract::ConnectInfo;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use axum::Extension;
+use hyper::{Method, StatusCode, Uri, Version};
+
+pub use radicle_cli::terminal::ansi::Paint;
+
+#[derive(Clone)]
+pub struct RequestId(Arc<AtomicU64>);
+
+impl RequestId {
+    pub fn new() -> RequestId {
+        RequestId(Arc::new(0.into()))
+    }
+
+    pub fn next(&mut self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+pub struct TracingInfo {
+    pub connect_info: ConnectInfo<SocketAddr>,
+    pub method: Method,
+    pub version: Version,
+    pub uri: Uri,
+}
+
+pub struct ColoredStatus(pub StatusCode);
+
+impl fmt::Display for ColoredStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.as_u16() {
+            200..=299 => write!(f, "{}", Paint::green(self.0)),
+            300..=399 => write!(f, "{}", Paint::blue(self.0)),
+            400..=499 => write!(f, "{}", Paint::red(self.0)),
+            _ => write!(f, "{}", Paint::yellow(self.0)),
+        }
+    }
+}
+
+pub async fn tracing_middleware<B>(request: Request<B>, next: Next<B>) -> impl IntoResponse {
+    let connect_info = *request
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+        .unwrap();
+
+    let method = request.method().clone();
+    let version = request.version();
+    let uri = request.uri().clone();
+
+    let tracing_info = TracingInfo {
+        connect_info,
+        method,
+        version,
+        uri,
+    };
+
+    let response = next.run(request).await;
+
+    (Extension(tracing_info), response)
+}


### PR DESCRIPTION
![Screenshot from 2023-03-02 18-10-49](https://user-images.githubusercontent.com/14107758/222460011-22719424-90c7-489d-b333-b6bd25f90b7c.png)

```bash
2023-03-02T14:37:01.282222Z  INFO radicle_httpd: version 0.1.0-1bb6f9a
2023-03-02T14:37:01.282780Z  INFO radicle_httpd: git version 2.34.1
2023-03-02T14:37:01.282943Z  INFO radicle_httpd: using radicle home at /tmp/rad_test
2023-03-02T14:37:01.283585Z  INFO radicle_httpd: listening on http://0.0.0.0:8080
2023-03-02T14:37:02.909666Z ERROR request{id=0}: radicle_httpd::error: invalid radicle identifier: Unknown base code: a
2023-03-02T14:37:02.909745Z  INFO request{id=0}: radicle_httpd: 127.0.0.1:35938 "GET /ax/xa HTTP/1.1" 404 Not Found 213.241µs 0
2023-03-02T14:37:03.816727Z  INFO request{id=1}: radicle_httpd: 127.0.0.1:35954 "GET /api/v1/projects/jk HTTP/1.1" 400 Bad Request 358.013µs 48
2023-03-02T14:37:05.393990Z  INFO request{id=2}: radicle_httpd: 127.0.0.1:35970 "GET /api/v1/projects/jk HTTP/1.1" 400 Bad Request 852.907µs 48
2023-03-02T14:37:11.344801Z  INFO request{id=3}: radicle_httpd: 127.0.0.1:54280 "GET /api/v1/projects HTTP/1.1" 200 OK 357.045µs 2
```

changelog

* a counter is added on every `Span`, and that's the only thing `Spans` will be holding from now on
* to conform with [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format)
  * added ip
  * added response size at the end of log
  * added version
  * re-arranged `"%method %uri %version"` e.g. `"GET /api/v1/projects HTTP/1.1"`
* added coloring to http status

things we can still change:

* timing format, Common Log Format uses `%d/%b/%Y:%H:%M:%S %z`
* position of `{id=0}` and shape, e.g. it could be in the beginning and missing `id=` part
* `targets` such as `radicle_httpd` or `radicle_httpd::error` can be omitted or re-arranged

note: any change to format of `trace` itself, and not the part we are constructing, requires a custom formatter.