### PR TITLE
radicle-httpd: Add patch creation endpoint

### DIFF
--- a/radicle-httpd/src/api/error.rs
+++ b/radicle-httpd/src/api/error.rs
@@ -34,6 +34,10 @@ pub enum Error {
     #[error(transparent)]
     CobIssue(#[from] radicle::cob::issue::Error),
 
+    /// Cob patch error.
+    #[error(transparent)]
+    CobPatch(#[from] radicle::cob::patch::Error),
+
     /// Cob store error.
     #[error(transparent)]
     CobStore(#[from] radicle::cob::store::Error),

--- a/radicle-httpd/src/test.rs
+++ b/radicle-httpd/src/test.rs
@@ -25,6 +25,7 @@ pub const HEAD: &str = "1e978d19f251cd9821d9d9a76d1bd436bf0690d5";
 pub const HEAD_1: &str = "f604ce9fd5b7cc77b7609beda45ea8760bee78f7";
 pub const PATCH_ID: &str = "afb3063f8f0343fa31d2a0d55bac2a6f4a77125e";
 pub const ISSUE_ID: &str = "331569cd5e4dcc55104363ebce92c78b0e5d67d4";
+pub const SESSION_ID: &str = "u9MGAkkfkMOv0uDDB2WeUHBT7HbsO2Dy";
 
 const PASSWORD: &str = "radicle";
 
@@ -144,7 +145,7 @@ pub async fn create_session(ctx: Context) {
     let issued_at = OffsetDateTime::now_utc();
     let mut sessions = ctx.sessions().write().await;
     sessions.insert(
-        String::from("u9MGAkkfkMOv0uDDB2WeUHBT7HbsO2Dy"),
+        String::from(SESSION_ID),
         auth::Session {
             status: auth::AuthState::Authorized,
             public_key: ctx.profile().public_key,


### PR DESCRIPTION
This PR adds a new endpoint to create new patches through the httpd that can be called as follows:

```
curl -H 'Content-Type: application/json' \
  -d '{ "title":<title>,"description":<description>, "target":<target_oid>, "oid":<head_oid>, "tags":[] }' \
  -X POST \
  -H "Authorization: Bearer <session_id>" \
  http://0.0.0.0:8080/api/v1/projects/:project/patches
```