### PR TITLE
fix: fix command line silent abort

### DIFF
--- a/radicle-cli/src/commands/issue.rs
+++ b/radicle-cli/src/commands/issue.rs
@@ -251,7 +251,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                 description.unwrap_or("Enter a description...".to_owned())
             );
 
-            if let Ok(Some(text)) = term::Editor::new().edit(&doc) {
+            if let Some(text) = term::Editor::new().edit(&doc)? {
                 let mut meta = String::new();
                 let mut frontmatter = false;
                 let mut lines = text.lines();


### PR DESCRIPTION
Fix the command line silents abort when the
the `EDITOR` variable is not specified.

With this commit the result is reported below

```
➜  rio git:(main) RAD_PASSPHRASE=12345 rad issue open
✗ Issue failed: editor not configured: the `EDITOR` environment variable is not set
```