### PR TITLE
[RFC] show the issue when it is created 

### DIFF
--- a/radicle-cli/examples/rad-issue.md
+++ b/radicle-cli/examples/rad-issue.md
@@ -5,6 +5,12 @@ Let's say the new car you are designing with your peers has a problem with its f
 
 ```
 $ rad issue open --title "flux capacitor underpowered" --description "Flux capacitor power requirements exceed current supply" --no-announce
+title: flux capacitor underpowered
+state: open
+tags: []
+assignees: []
+
+Flux capacitor power requirements exceed current supply
 ```
 
 The issue is now listed under our project.


### PR DESCRIPTION
After an issue is opened there is no feedback from the command line
that the issue is created correctly, so this is calling `show_issue` to 
print the issue result on the command line.

Also, I'm proposing a new show issue format on the terminal
because the previous one looks a little bit odd to me in
comparison with the other rad commands.