### PR TITLE
node: use enum for fetch direction

### DIFF
--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -16,6 +16,7 @@ use crate::prelude::{LocalDuration, Timestamp};
 use crate::service::config::*;
 use crate::service::filter::Filter;
 use crate::service::message::*;
+use crate::service::reactor::FetchDirection;
 use crate::service::reactor::Io;
 use crate::service::ServiceState as _;
 use crate::service::*;
@@ -646,9 +647,10 @@ fn test_gossip_during_fetch() {
     alice.fetched(
         Fetch {
             rid,
-            namespaces: Namespaces::All,
+            direction: FetchDirection::Initiator {
+                namespaces: Namespaces::All,
+            },
             remote: bob.id,
-            initiated: true,
         },
         Ok(vec![]),
     );

--- a/radicle-node/src/wire/protocol.rs
+++ b/radicle-node/src/wire/protocol.rs
@@ -110,7 +110,7 @@ impl std::fmt::Debug for Peer {
             } => write!(
                 f,
                 "Upgrading(initiated={}, {link:?}, {id})",
-                fetch.initiated
+                fetch.is_initiator(),
             ),
             Self::Upgraded { link, id, .. } => write!(f, "Upgraded({link:?}, {id})"),
         }


### PR DESCRIPTION
A fetch is a client-server interaction and so there are two sides to this interaction. These sides are generally referred to as receive -- the client side -- and upload -- the server side.

The `Fetch` type indicated whether it was doing a receive or upload by using a field `initiated: bool`. However, this can be confusing when you pair it with the `namespaces: Namespaces` field, since only the receive side should be sending what refspecs it wants and the upload side responds with those matching refspecs.

A better way to represent this is using an enum for which direction the fetch is being considered, where the receive side contains the Namespaces.

The resulting code then makes decisions based on what variant of the enum was passed.

Fixes #379 
