### PR TITLE
cli: add merge target option to `rad patch`

### DIFF
--- a/radicle-cli/src/commands/patch/common.rs
+++ b/radicle-cli/src/commands/patch/common.rs
@@ -49,6 +49,8 @@ pub struct MergeTargets {
 }
 
 /// Find potential merge targets for the given head.
+///
+/// Only delegates can be merge targets.
 pub fn find_merge_targets(
     head: &Oid,
     branch: &git::RefStr,
@@ -56,8 +58,8 @@ pub fn find_merge_targets(
 ) -> anyhow::Result<MergeTargets> {
     let mut targets = MergeTargets::default();
 
-    for remote in storage.remotes()? {
-        let (_, remote) = remote?;
+    for delegate in storage.delegates()? {
+        let remote = storage.remote(&delegate)?;
         let Some(target_oid) = remote.refs.head(branch) else {
             continue;
         };
@@ -89,7 +91,6 @@ pub fn get_merge_target(
     let (target_peer, target_oid) = match targets.not_merged.as_slice() {
         [] => {
             spinner.message("All tracked peers are up to date.");
-            todo!("handle case without target");
         }
         [target] => target,
         _ => {

--- a/radicle-cli/src/commands/patch/create.rs
+++ b/radicle-cli/src/commands/patch/create.rs
@@ -131,6 +131,14 @@ pub fn run(
         anyhow::bail!("patch proposal aborted by user");
     }
 
+    // o <- target oid
+    // |
+    // o   o <- head oid
+    // |  /
+    // o o
+    // |/
+    // o <- merge base
+    //
     let head_oid = branch_oid(&head_branch)?;
     let base_oid = workdir.merge_base(*target_oid, *head_oid)?;
     let patch = patches.create(


### PR DESCRIPTION
Providing a merge target as a command line option supports using the command in scripts.

```
rad patch open --target <peer>
```