### PR TITLE
node: Handle `FetchOk` never being received

### DIFF
--- a/radicle-node/src/service/session.rs
+++ b/radicle-node/src/service/session.rs
@@ -292,8 +292,21 @@ impl Session {
         };
     }
 
-    pub fn to_disconnected(&mut self, since: LocalTime) {
+    /// Move the session state to "disconnected". Returns any pending RID
+    /// that was requested.
+    pub fn to_disconnected(&mut self, since: LocalTime) -> Option<Id> {
+        let request = if let State::Connected {
+            protocol: Protocol::Gossip { requested },
+            ..
+        } = self.state
+        {
+            requested
+        } else {
+            None
+        };
         self.state = State::Disconnected { since };
+
+        request
     }
 
     pub fn ping(&mut self, reactor: &mut Reactor) -> Result<(), Error> {


### PR DESCRIPTION
It's possible for a peer to disconnect before responding with `FetchOk`. In that case, we make sure to return to any pending fetch request with an error. Closes #382 