### PR TITLE
cob: Use `EntryId` as the operation identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,7 +1807,6 @@ dependencies = [
  "radicle-crypto",
  "radicle-git-ext",
  "radicle-ssh",
- "rand 0.8.5",
  "serde",
  "serde_json",
  "siphasher",

--- a/radicle-cli/examples/rad-id-rebase.md
+++ b/radicle-cli/examples/rad-id-rebase.md
@@ -6,7 +6,7 @@ delegates creating proposals concurrently.
 
 ```
 $ rad id edit --title "Add Alice" --description "Add Alice as a delegate" --delegates did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
-✓ Identity proposal '6e4dfd0edbb0974f5a4fb0990133e0911b0992c0' created 🌱
+✓ Identity proposal '04603c0d3ea4d137487024a51c9360adfc511114' created 🌱
 title: Add Alice
 description: Add Alice as a delegate
 status: ❲open❳
@@ -48,7 +48,7 @@ Quorum Reached
 
 ```
 $ rad id edit --title "Add Bob" --description "Add Bob as a delegate" --delegates did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG --no-confirm
-✓ Identity proposal '6a687267b5063c036fdde90b75cc5eb153fa25e8' created 🌱
+✓ Identity proposal '3f6ae4f8645c8b0cbcd35ea924df7b13aca52774' created 🌱
 title: Add Bob
 description: Add Bob as a delegate
 status: ❲open❳
@@ -93,7 +93,7 @@ second proposal, then the identity would be out of date. So let's run
 through that and see what happens.
 
 ```
-$ rad id accept 6e4dfd0edbb0974f5a4fb0990133e0911b0992c0 --no-confirm
+$ rad id accept 04603c0d3ea4d137487024a51c9360adfc511114 --no-confirm
 ✓ Accepted proposal ✓
 title: Add Alice
 description: Add Alice as a delegate
@@ -137,7 +137,7 @@ Quorum Reached
 ```
 
 ```
-$ rad id commit 6e4dfd0edbb0974f5a4fb0990133e0911b0992c0 --no-confirm
+$ rad id commit 04603c0d3ea4d137487024a51c9360adfc511114 --no-confirm
 ✓ Committed new identity '29ae4b72f5a315328f06fbd68dc1c396a2d5c45e' 🌱
 title: Add Alice
 description: Add Alice as a delegate
@@ -183,7 +183,7 @@ Quorum Reached
 Now, when we go to accept the second proposal:
 
 ```
-$ rad id accept 6a687267b5063c036fdde90b75cc5eb153fa25e8 --no-confirm
+$ rad id accept 3f6ae4f8645c8b0cbcd35ea924df7b13aca52774 --no-confirm
 ! Warning: Revision is out of date
 ! Warning: d96f425412c9f8ad5d9a9a05c9831d0728e2338d =/= 475cdfbc8662853dd132ec564e4f5eb0f152dd7f
 👉 Consider using 'rad id rebase' to update the proposal to the latest identity
@@ -238,19 +238,19 @@ Note that a warning was emitted:
 If we attempt to commit this revision, the command will fail:
 
 ```
-$ rad id commit 6a687267b5063c036fdde90b75cc5eb153fa25e8 --no-confirm
+$ rad id commit 3f6ae4f8645c8b0cbcd35ea924df7b13aca52774 --no-confirm
 ! Warning: Revision is out of date
 ! Warning: d96f425412c9f8ad5d9a9a05c9831d0728e2338d =/= 475cdfbc8662853dd132ec564e4f5eb0f152dd7f
 👉 Consider using 'rad id rebase' to update the proposal to the latest identity
-✗ Id failed: the identity hashes do match 'd96f425412c9f8ad5d9a9a05c9831d0728e2338d =/= 475cdfbc8662853dd132ec564e4f5eb0f152dd7f' for the revision '6877dc63e001e7f7fcb285f5f530948b3d96b488'
+✗ Id failed: the identity hashes do match 'd96f425412c9f8ad5d9a9a05c9831d0728e2338d =/= 475cdfbc8662853dd132ec564e4f5eb0f152dd7f' for the revision '3f6ae4f8645c8b0cbcd35ea924df7b13aca52774'
 ```
 
 So, let's fix this by running a rebase on the proposal's revision:
 
 ```
-$ rad id rebase 6a687267b5063c036fdde90b75cc5eb153fa25e8 --no-confirm
-✓ Identity proposal '6a687267b5063c036fdde90b75cc5eb153fa25e8' rebased 🌱
-✓ Revision 'aaa890c3531f880c9901b162ab38016ceb559c9f'
+$ rad id rebase 3f6ae4f8645c8b0cbcd35ea924df7b13aca52774 --no-confirm
+✓ Identity proposal '3f6ae4f8645c8b0cbcd35ea924df7b13aca52774' rebased 🌱
+✓ Revision '42b9428df59ad349f706b1397750b75ea3b42574'
 title: Add Bob
 description: Add Bob as a delegate
 status: ❲open❳
@@ -293,9 +293,9 @@ Quorum Reached
 We can now update the proposal to have both keys in the delegates set:
 
 ```
-$ rad id update 6a687267b5063c036fdde90b75cc5eb153fa25e8 --rev aaa890c3531f880c9901b162ab38016ceb559c9f --delegates did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
-✓ Identity proposal '6a687267b5063c036fdde90b75cc5eb153fa25e8' updated 🌱
-✓ Revision '24ad4a6ce84b1ce4b8cc754494c23f1079020a14'
+$ rad id update 3f6ae4f8645c8b0cbcd35ea924df7b13aca52774 --rev 42b9428df59ad349f706b1397750b75ea3b42574 --delegates did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
+✓ Identity proposal '3f6ae4f8645c8b0cbcd35ea924df7b13aca52774' updated 🌱
+✓ Revision '1b4ded759249e4f76d19c3e580b4736bf2a2d1c4'
 title: Add Bob
 description: Add Bob as a delegate
 status: ❲open❳
@@ -338,10 +338,10 @@ Quorum Reached
 Finally, we can accept and commit this proposal, creating the final
 state of our new Radicle identity:
 
-$ rad id show 6a687267b5063c036fdde90b75cc5eb153fa25e8 --revisions
+$ rad id show 3f6ae4f8645c8b0cbcd35ea924df7b13aca52774 --revisions
 
 ```
-$ rad id accept 6a687267b5063c036fdde90b75cc5eb153fa25e8 --rev 24ad4a6ce84b1ce4b8cc754494c23f1079020a14 --no-confirm
+$ rad id accept 3f6ae4f8645c8b0cbcd35ea924df7b13aca52774 --rev 1b4ded759249e4f76d19c3e580b4736bf2a2d1c4 --no-confirm
 ✓ Accepted proposal ✓
 title: Add Bob
 description: Add Bob as a delegate
@@ -385,7 +385,7 @@ Quorum Reached
 ```
 
 ```
-$ rad id commit 6a687267b5063c036fdde90b75cc5eb153fa25e8 --rev 24ad4a6ce84b1ce4b8cc754494c23f1079020a14 --no-confirm
+$ rad id commit 3f6ae4f8645c8b0cbcd35ea924df7b13aca52774 --rev 1b4ded759249e4f76d19c3e580b4736bf2a2d1c4 --no-confirm
 ✓ Committed new identity '60de897bc24898f6908fd1272633c0b15aa4096f' 🌱
 title: Add Bob
 description: Add Bob as a delegate

--- a/radicle-cli/examples/rad-id.md
+++ b/radicle-cli/examples/rad-id.md
@@ -14,7 +14,7 @@ Let's add Bob as a delegate using their DID
 
 ```
 $ rad id edit --title "Add Bob" --description "Add Bob as a delegate" --delegates did:key:z6MkedTZGJGqgQ2py2b8kGecfxdt2yRdHWF6JpaZC47fovFn --no-confirm
-✓ Identity proposal 'd4ceabea6b7acc91a92c040274e4578d9158a24b' created 🌱
+✓ Identity proposal '0d396a83a5e1dda2b8929f7dc401d19dd1a79fb8' created 🌱
 title: Add Bob
 description: Add Bob as a delegate
 status: ❲open❳
@@ -89,7 +89,7 @@ Finally, we can see whether the `Quorum` was reached:
 Let's see what happens when we reject the change:
 
 ```
-$ rad id reject d4ceabea6b7acc91a92c040274e4578d9158a24b --no-confirm
+$ rad id reject 0d396a83a5e1dda2b8929f7dc401d19dd1a79fb8 --no-confirm
 ✓ Rejected proposal 👎
 title: Add Bob
 description: Add Bob as a delegate
@@ -145,7 +145,7 @@ increased to `1`.
 Instead, let's accept the proposal:
 
 ```
-$ rad id accept d4ceabea6b7acc91a92c040274e4578d9158a24b --no-confirm
+$ rad id accept 0d396a83a5e1dda2b8929f7dc401d19dd1a79fb8 --no-confirm
 ✓ Accepted proposal ✓
 title: Add Bob
 description: Add Bob as a delegate
@@ -207,7 +207,7 @@ As well as that, the `Quorum` has now been reached:
 At this point, we can commit the proposal and update the identity:
 
 ```
-$ rad id commit d4ceabea6b7acc91a92c040274e4578d9158a24b --no-confirm
+$ rad id commit 0d396a83a5e1dda2b8929f7dc401d19dd1a79fb8 --no-confirm
 ✓ Committed new identity 'c96e764965aaeff1c6ea3e5b97e2b9828773c8b0' 🌱
 title: Add Bob
 description: Add Bob as a delegate
@@ -255,7 +255,7 @@ the `--threshold` option:
 
 ```
 $ rad id edit --title "Update threshold" --description "Update to safer threshold" --threshold 2 --no-confirm
-✓ Identity proposal 'b54d8c5fbe42236c9210f39c4051cd223a884b7c' created 🌱
+✓ Identity proposal 'f435d6e89c8f922ede691287c0d8b7f82afa591e' created 🌱
 title: Update threshold
 description: Update to safer threshold
 status: ❲open❳
@@ -298,8 +298,8 @@ Quorum Reached
 But we change our minds and decide to close the proposal instead:
 
 ```
-$ rad id close b54d8c5fbe42236c9210f39c4051cd223a884b7c --no-confirm
-✓ Closed identity proposal 'b54d8c5fbe42236c9210f39c4051cd223a884b7c'
+$ rad id close f435d6e89c8f922ede691287c0d8b7f82afa591e --no-confirm
+✓ Closed identity proposal 'f435d6e89c8f922ede691287c0d8b7f82afa591e'
 title: Update threshold
 description: Update to safer threshold
 status: ❲closed❳
@@ -348,15 +348,15 @@ Radicle identity, then we can use the list command:
 
 ```
 $ rad id list
-b54d8c5fbe42236c9210f39c4051cd223a884b7c "Update threshold" ❲closed❳
-d4ceabea6b7acc91a92c040274e4578d9158a24b "Add Bob"          ❲committed❳
+0d396a83a5e1dda2b8929f7dc401d19dd1a79fb8 "Add Bob"          ❲committed❳
+f435d6e89c8f922ede691287c0d8b7f82afa591e "Update threshold" ❲closed❳
 ```
 
 And if we want to view the latest state of any proposal we can use the
 show command:
 
 ```
-$ rad id show b54d8c5fbe42236c9210f39c4051cd223a884b7c
+$ rad id show f435d6e89c8f922ede691287c0d8b7f82afa591e
 title: Update threshold
 description: Update to safer threshold
 status: ❲closed❳

--- a/radicle-cli/examples/rad-issue.md
+++ b/radicle-cli/examples/rad-issue.md
@@ -11,7 +11,7 @@ The issue is now listed under our project.
 
 ```
 $ rad issue list
-e8eb9ca4afa050499b259842ddef2d41abf0fd83 "flux capacitor underpowered"
+2e8c1bf3fe0532a314778357c886608a966a34bd "flux capacitor underpowered"
 ```
 
 Great! Now we've documented the issue for ourselves and others.
@@ -22,20 +22,20 @@ others to work on.  This is to ensure work is not duplicated.
 Let's assign ourselves to this one.
 
 ```
-$ rad assign e8eb9ca4afa050499b259842ddef2d41abf0fd83 did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad assign 2e8c1bf3fe0532a314778357c886608a966a34bd did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 It will now show in the list of issues assigned to us.
 
 ```
 $ rad issue list --assigned
-e8eb9ca4afa050499b259842ddef2d41abf0fd83 "flux capacitor underpowered" did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+2e8c1bf3fe0532a314778357c886608a966a34bd "flux capacitor underpowered" did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Note: this can always be undone with the `unassign` subcommand.
 
 ```
-$ rad unassign e8eb9ca4afa050499b259842ddef2d41abf0fd83 did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+$ rad unassign 2e8c1bf3fe0532a314778357c886608a966a34bd did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
 ```
 
 Great, now we have communicated to the world about our car's defect.
@@ -44,8 +44,8 @@ But wait! We've found an important detail about the car's power requirements.
 It will help whoever works on a fix.
 
 ```
-$ rad comment e8eb9ca4afa050499b259842ddef2d41abf0fd83 --message 'The flux capacitor needs 1.21 Gigawatts'
-f1895792f7b1b56590aa21e34454bde74d04649a
-$ rad comment e8eb9ca4afa050499b259842ddef2d41abf0fd83 --reply-to f1895792f7b1b56590aa21e34454bde74d04649a --message 'More power!'
-0bf5f874c57ac0a5cc010a9895dd0fec9edc4f3d
+$ rad comment 2e8c1bf3fe0532a314778357c886608a966a34bd --message 'The flux capacitor needs 1.21 Gigawatts'
+9822748bd076595a2408aad02b3a0d9f94fec7e0
+$ rad comment 2e8c1bf3fe0532a314778357c886608a966a34bd --reply-to 9822748bd076595a2408aad02b3a0d9f94fec7e0 --message 'More power!'
+edec8d07bf3788b98943394c1274910b8f12d35c
 ```

--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -35,7 +35,7 @@ z6MknSL…StBU8Vi/master (f2de534) <- z6MknSL…StBU8Vi/flux-capacitor-power (3e
 
 3e674d1 Define power requirements
 
-✓ Patch d8584d098142d774211ac5cdc8d1df4a113875dd created 🌱
+✓ Patch 191a14e520f2eeff7c0e3ee0a5523c5217eecb89 created 🌱
 
 To publish your patch to the network, run:
     rad push
@@ -49,15 +49,15 @@ $ rad patch
 
 ❲YOU PROPOSED❳
 
-Define power requirements d8584d09814 R0 3e674d1 (flux-capacitor-power) ahead 1, behind 0
+Define power requirements 191a14e520f R0 3e674d1 (flux-capacitor-power) ahead 1, behind 0
 └─ * opened by did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi (you) [..]
-└─ * patch id d8584d098142d774211ac5cdc8d1df4a113875dd
+└─ * patch id 191a14e520f2eeff7c0e3ee0a5523c5217eecb89
 
 ❲OTHERS PROPOSED❳
 
 Nothing to show.
 
-$ rad patch show d8584d098142d774211ac5cdc8d1df4a113875dd
+$ rad patch show 191a14e520f2eeff7c0e3ee0a5523c5217eecb89
 
 Define power requirements
 
@@ -84,34 +84,34 @@ $ git commit --message "Add README, just for the fun"
 [flux-capacitor-power 27857ec] Add README, just for the fun
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 README.md
-$ rad patch update --message "Add README, just for the fun" d8584d098142d774211ac5cdc8d1df4a113875dd
+$ rad patch update --message "Add README, just for the fun" 191a14e520f2eeff7c0e3ee0a5523c5217eecb89
 
 🌱 Updating patch for heartwood
 
 ✓ Pushing HEAD to storage...
 ✓ Analyzing remotes...
 
-d8584d09814 R0 (3e674d1) -> R1 (27857ec)
+191a14e520f R0 (3e674d1) -> R1 (27857ec)
 1 commit(s) ahead, 0 commit(s) behind
 
 
-✓ Patch d8584d098142d774211ac5cdc8d1df4a113875dd updated 🌱
+✓ Patch 191a14e520f2eeff7c0e3ee0a5523c5217eecb89 updated 🌱
 
 ```
 
 And lets leave a quick comment for our team:
 
 ```
-$ rad comment d8584d098142d774211ac5cdc8d1df4a113875dd --message 'I cannot wait to get back to the 90s!'
-84ef44764de73695cf30e6b284585d2c50d6d0e5
-$ rad comment d8584d098142d774211ac5cdc8d1df4a113875dd --message 'I cannot wait to get back to the 90s!' --reply-to 84ef44764de73695cf30e6b284585d2c50d6d0e5
-2fa3ac18d82ebdafe73484a15fa9823355c4664b
+$ rad comment 191a14e520f2eeff7c0e3ee0a5523c5217eecb89 --message 'I cannot wait to get back to the 90s!'
+70fc8b18300096f6f0f919797457244e6e4b2cea
+$ rad comment 191a14e520f2eeff7c0e3ee0a5523c5217eecb89 --message 'I cannot wait to get back to the 90s!' --reply-to 70fc8b18300096f6f0f919797457244e6e4b2cea
+7a9f7a6358238f4ff115d2b2a5e522ab93867d38
 ```
 
 Now, let's checkout the patch that we just created:
 
 ```
-$ rad patch checkout d8584d098142d774211ac5cdc8d1df4a113875dd
+$ rad patch checkout 191a14e520f2eeff7c0e3ee0a5523c5217eecb89
 ✓ Performing patch checkout...
-✓ Switched to branch patch/d8584d09814
+✓ Switched to branch patch/191a14e520f
 ```

--- a/radicle-cob/src/backend/git/change.rs
+++ b/radicle-cob/src/backend/git/change.rs
@@ -110,17 +110,8 @@ impl change::Storage for git2::Repository {
             history_type,
         };
 
-        let (revision, blob_oids) = write_manifest(self, &manifest, &contents)?;
+        let revision = write_manifest(self, &manifest, &contents)?;
         let tree = self.find_tree(revision)?;
-        let contents = NonEmpty::collect(blob_oids.into_iter().zip(contents).map(|(oid, op)| {
-            entry::EntryBlob {
-                oid: oid.into(),
-                data: op,
-            }
-        }))
-        // SAFETY: We know it's not empty because the original `contents` is `NonEmpty`.
-        .unwrap();
-
         let signature = {
             let sig = signer.sign(revision.as_bytes());
             let key = signer.public_key();
@@ -216,7 +207,7 @@ fn load_contents(
                     let blob = entry
                         .to_object(repo)
                         .and_then(|object| object.peel_to_blob())
-                        .map(entry::EntryBlob::from)
+                        .map(|blob| blob.content().to_owned())
                         .map(|b| (name, b));
 
                     Some(blob)
@@ -291,7 +282,7 @@ fn write_manifest(
     repo: &git2::Repository,
     manifest: &store::Manifest,
     contents: &NonEmpty<Vec<u8>>,
-) -> Result<(git2::Oid, Vec<git2::Oid>), git2::Error> {
+) -> Result<git2::Oid, git2::Error> {
     let mut tb = repo.treebuilder(None)?;
     // SAFETY: we're serializing to an in memory buffer so the only source of
     // errors here is a programming error, which we can't recover from
@@ -303,13 +294,11 @@ fn write_manifest(
         git2::FileMode::Blob.into(),
     )?;
 
-    let mut blob_oids = Vec::new();
     for (ix, op) in contents.iter().enumerate() {
         let oid = repo.blob(op.as_ref())?;
         tb.insert(&ix.to_string(), oid, git2::FileMode::Blob.into())?;
-        blob_oids.push(oid);
     }
     let tree_oid = tb.write()?;
 
-    Ok((tree_oid, blob_oids))
+    Ok(tree_oid)
 }

--- a/radicle-cob/src/change_graph/evaluation.rs
+++ b/radicle-cob/src/change_graph/evaluation.rs
@@ -40,12 +40,7 @@ pub fn evaluate(root: Oid, graph: &Dag<Oid, Change>, rng: fastrand::Rng) -> hist
                 let clock = graph[&c.oid]
                     .dependencies
                     .iter()
-                    .map(|e| {
-                        let entry = &entries[&EntryId::from(*e)];
-                        let clock = entry.range();
-
-                        *clock.end()
-                    })
+                    .map(|e| entries[&EntryId::from(*e)].clock())
                     .max()
                     .unwrap_or_default() // When there are no operations, the clock is zero.
                     + 1;

--- a/radicle-cob/src/history.rs
+++ b/radicle-cob/src/history.rs
@@ -80,7 +80,7 @@ impl History {
     pub fn clock(&self) -> Clock {
         self.graph
             .tips()
-            .map(|(_, node)| node.clock + node.entry.contents.len() as Clock - 1)
+            .map(|(_, node)| node.clock)
             .max()
             .unwrap_or_default()
     }

--- a/radicle-cob/src/lib.rs
+++ b/radicle-cob/src/lib.rs
@@ -98,7 +98,7 @@ pub use type_name::TypeName;
 
 pub mod object;
 pub use object::{
-    create, get, info, list, remove, update, CollaborativeObject, Create, ObjectId, Update,
+    create, get, info, list, remove, update, CollaborativeObject, Create, ObjectId, Update, Updated,
 };
 
 #[cfg(test)]

--- a/radicle-cob/src/object.rs
+++ b/radicle-cob/src/object.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 pub mod collaboration;
 pub use collaboration::{
     create, get, info, list, parse_refstr, remove, update, CollaborativeObject, Create, Update,
+    Updated,
 };
 
 pub mod storage;

--- a/radicle-cob/src/object/collaboration.rs
+++ b/radicle-cob/src/object/collaboration.rs
@@ -27,7 +27,7 @@ mod remove;
 pub use remove::remove;
 
 mod update;
-pub use update::{update, Update};
+pub use update::{update, Update, Updated};
 
 /// A collaborative object
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/radicle-cob/src/object/collaboration/update.rs
+++ b/radicle-cob/src/object/collaboration/update.rs
@@ -10,6 +10,15 @@ use crate::{change, change_graph::ChangeGraph, CollaborativeObject, ObjectId, St
 
 use super::error;
 
+/// Result of an `update` operation.
+#[derive(Debug)]
+pub struct Updated {
+    /// The new head commit of the DAG.
+    pub head: Oid,
+    /// The newly updated collaborative object.
+    pub object: CollaborativeObject,
+}
+
 /// The data required to update an object
 pub struct Update {
     /// The type of history that will be used for this object.
@@ -48,7 +57,7 @@ pub fn update<S, G>(
     resource: Oid,
     identifier: &S::Identifier,
     args: Update,
-) -> Result<CollaborativeObject, error::Update>
+) -> Result<Updated, error::Update>
 where
     S: Store,
     G: crypto::Signer,
@@ -93,5 +102,8 @@ where
         change.timestamp,
     );
 
-    Ok(object)
+    Ok(Updated {
+        object,
+        head: change.id,
+    })
 }

--- a/radicle-httpd/src/api/error.rs
+++ b/radicle-httpd/src/api/error.rs
@@ -81,10 +81,17 @@ impl IntoResponse for Error {
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Some(e.message().to_owned()),
             ),
-            _ => {
+            other => {
                 tracing::error!("Error: {:?}", &self);
 
-                (StatusCode::INTERNAL_SERVER_ERROR, None)
+                if cfg!(debug_assertions) {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Some(format!("{other:?}")),
+                    )
+                } else {
+                    (StatusCode::INTERNAL_SERVER_ERROR, None)
+                }
             }
         };
 

--- a/radicle-httpd/src/api/json.rs
+++ b/radicle-httpd/src/api/json.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use radicle::cob::issue::{Issue, IssueId};
 use radicle::cob::patch::{Patch, PatchId};
 use radicle::cob::thread::{self, CommentId};
-use radicle::cob::{Author, OpId, Timestamp};
+use radicle::cob::{Author, Timestamp};
 use radicle_surf::blob::Blob;
 use radicle_surf::tree::Tree;
 use radicle_surf::{Commit, Stats};
@@ -132,7 +132,7 @@ fn name_in_path(path: &str) -> &str {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Comment {
-    id: OpId,
+    id: CommentId,
     author: Author,
     body: String,
     reactions: [String; 0],

--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -1104,7 +1104,7 @@ mod routes {
                 "assignees": [],
                 "discussion": [
                   {
-                    "id": ISSUE_DISCUSSION_ID,
+                    "id": ISSUE_ID,
                     "author": {
                         "id": "did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi"
                     },
@@ -1122,7 +1122,7 @@ mod routes {
 
     #[tokio::test]
     async fn test_projects_issues_create() {
-        const CREATED_ISSUE_ID: &str = "1b706bb9af971d43ec38718c71402e36055c5c89";
+        const CREATED_ISSUE_ID: &str = "b457364fbe2ef0eac69a835a087f60ee13ccb367";
 
         let tmp = tempfile::tempdir().unwrap();
         let ctx = test::contributor(tmp.path());
@@ -1171,7 +1171,7 @@ mod routes {
                   "status": "open",
               },
               "discussion": [{
-                  "id": ISSUE_DISCUSSION_ID,
+                  "id": CREATED_ISSUE_ID,
                   "author": {
                       "id": CONTRIBUTOR_PUB_KEY,
                   },
@@ -1245,7 +1245,7 @@ mod routes {
                   "replyTo": null,
                 },
                 {
-                  "id": "265af21e409eacc8eb150b73882ac3ada9d4aea3",
+                  "id": "9685b141c2e939c3d60f8ca34f8c7bf01a609af1",
                   "author": {
                       "id": CONTRIBUTOR_PUB_KEY,
                   },
@@ -1269,7 +1269,7 @@ mod routes {
         test::create_session(ctx).await;
 
         let body = serde_json::to_vec(&json!({
-          "type":"thread",
+          "type": "thread",
           "action": {
             "type": "comment",
             "body": "This is a reply to the first comment",
@@ -1277,9 +1277,7 @@ mod routes {
         }}))
         .unwrap();
 
-        let response = get(&app, format!("/projects/{CONTRIBUTOR_RID}/issues")).await;
-        println!("{:?}", response.json().await);
-
+        let _ = get(&app, format!("/projects/{CONTRIBUTOR_RID}/issues")).await;
         let response = patch(
             &app,
             format!("/projects/{CONTRIBUTOR_RID}/issues/{CONTRIBUTOR_ISSUE_ID}"),
@@ -1358,7 +1356,7 @@ mod routes {
                 "tags": [],
                 "revisions": [
                     {
-                        "id": "47878ed82515772f4c44e4796c330f4a74473559",
+                        "id": PATCH_ID,
                         "description": "",
                         "reviews": [],
                     }
@@ -1389,7 +1387,7 @@ mod routes {
                 "tags": [],
                 "revisions": [
                     {
-                        "id": "47878ed82515772f4c44e4796c330f4a74473559",
+                        "id": PATCH_ID,
                         "description": "",
                         "reviews": [],
                     }
@@ -1401,7 +1399,7 @@ mod routes {
 
     #[tokio::test]
     async fn test_projects_create_patches() {
-        const CREATED_PATCH_ID: &str = "22f8fbe09f7430579dd0730e4f2394362d844647";
+        const CREATED_PATCH_ID: &str = "54505091ff3561466cfbe83e7e23c21cb1bb8a17";
 
         let tmp = tempfile::tempdir().unwrap();
         let ctx = test::contributor(tmp.path());
@@ -1459,7 +1457,7 @@ mod routes {
                 "tags": [],
                 "revisions": [
                     {
-                        "id": "73efc59cd9f787deff0ae1629f47f1d90f307282",
+                        "id": CREATED_PATCH_ID,
                         "description": "",
                         "reviews": [],
                     }

--- a/radicle/Cargo.toml
+++ b/radicle/Cargo.toml
@@ -24,7 +24,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 siphasher = { version = "0.3.10" }
 radicle-git-ext = { version = "0", features = ["serde"] }
-rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 sqlite = { version = "0.30.3", optional = true }
 tempfile = { version = "3.3.0" }
 thiserror = { version = "1" }

--- a/radicle/src/cob.rs
+++ b/radicle/src/cob.rs
@@ -11,10 +11,10 @@ pub mod test;
 
 pub use cob::{create, get, list, remove, update};
 pub use cob::{
-    history::entry::EntryBlob, object::collaboration::error, CollaborativeObject, Contents, Create,
-    Entry, History, ObjectId, TypeName, Update,
+    history::EntryId, object::collaboration::error, CollaborativeObject, Contents, Create, Entry,
+    History, ObjectId, TypeName, Update, Updated,
 };
 pub use common::*;
-pub use op::{ActorId, Op, OpId};
+pub use op::{ActorId, Op};
 
 use radicle_cob as cob;

--- a/radicle/src/cob/op.rs
+++ b/radicle/src/cob/op.rs
@@ -1,106 +1,13 @@
-use std::fmt;
-use std::str;
-use std::str::FromStr;
-
 use nonempty::NonEmpty;
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use radicle_cob::history::EntryWithClock;
+use radicle_cob::history::{EntryId, EntryWithClock};
 use radicle_crdt::clock;
 use radicle_crdt::clock::Lamport;
 use radicle_crypto::PublicKey;
 
-use crate::git;
-
-/// Identifies an [`Op`] internally and within the change graph.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(into = "String", try_from = "String")]
-pub struct OpId(git::Oid);
-
-impl OpId {
-    /// Create a new operation id.
-    pub fn new(oid: git::Oid) -> Self {
-        Self(oid)
-    }
-}
-
-impl fmt::Display for OpId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<OpId> for git::Oid {
-    fn from(value: OpId) -> Self {
-        value.0
-    }
-}
-
-impl From<OpId> for git2::Oid {
-    fn from(value: OpId) -> Self {
-        value.0.into()
-    }
-}
-
-impl From<git::Oid> for OpId {
-    fn from(value: git::Oid) -> Self {
-        Self(value)
-    }
-}
-
-impl From<git2::Oid> for OpId {
-    fn from(value: git2::Oid) -> Self {
-        Self(value.into())
-    }
-}
-
-// Used by `serde::Serialize`.
-impl From<OpId> for String {
-    fn from(value: OpId) -> Self {
-        value.to_string()
-    }
-}
-
-// Used by `serde::Deserialize`.
-impl TryFrom<String> for OpId {
-    type Error = git::raw::Error;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        value.as_str().try_into()
-    }
-}
-
-/// Error decoding an operation from an entry.
-#[derive(Error, Debug)]
-pub enum OpIdError {
-    #[error("cannot parse op id from empty string")]
-    Empty,
-    #[error("badly formatted op id")]
-    BadFormat,
-}
-
-impl FromStr for OpId {
-    type Err = git::raw::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::try_from(s)
-    }
-}
-
-impl TryFrom<&str> for OpId {
-    type Error = git::raw::Error;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        git::Oid::try_from(s).map(Self)
-    }
-}
-
 /// The author of an [`Op`].
 pub type ActorId = PublicKey;
-
-/// Random number used to prevent op-id collisions.
-pub type Nonce = u64;
 
 /// Error decoding an operation from an entry.
 #[derive(Error, Debug)]
@@ -111,29 +18,16 @@ pub enum OpEncodingError {
     Git(#[from] git2::Error),
 }
 
-/// The operation payload that is actually stored on disk as a git blob.
-#[derive(Debug, Clone, Deserialize)]
-pub struct OpBlob<A> {
-    /// The underlying action.
-    pub action: A,
-    /// A random number used to disambiguate otherwise identical ops (actions).
-    /// Note that since the timestamp and author are not stored at the individual op level,
-    /// but instead at the commit level; individual ops can trivially collide.
-    pub nonce: Nonce,
-}
-
 /// The `Op` is the operation that is applied onto a state to form a CRDT.
 ///
 /// Everything that can be done in the system is represented by an `Op`.
 /// Operations are applied to an accumulator to yield a final state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Op<A> {
-    /// Operation id.
-    pub id: OpId,
+    /// Id of the entry under which this operation lives.
+    pub id: EntryId,
     /// The action carried out by this operation.
     pub action: A,
-    /// The nonce from the [`OpBlob`].
-    pub nonce: Nonce,
     /// The author of the operation.
     pub author: ActorId,
     /// Lamport clock.
@@ -156,9 +50,8 @@ impl<A: Eq> Ord for Op<A> {
 
 impl<A> Op<A> {
     pub fn new(
-        id: OpId,
+        id: EntryId,
         action: A,
-        nonce: Nonce,
         author: ActorId,
         timestamp: impl Into<clock::Physical>,
         clock: Lamport,
@@ -166,14 +59,13 @@ impl<A> Op<A> {
         Self {
             id,
             action,
-            nonce,
             author,
             clock,
             timestamp: timestamp.into(),
         }
     }
 
-    pub fn id(&self) -> OpId {
+    pub fn id(&self) -> EntryId {
         self.id
     }
 }
@@ -187,16 +79,16 @@ where
     type Error = OpEncodingError;
 
     fn try_from(entry: &'a EntryWithClock) -> Result<Self, Self::Error> {
+        let id = *entry.id();
         let ops = entry
             .changes()
-            .map(|(clock, blob)| {
-                let OpBlob { action, nonce } = serde_json::from_slice(blob.data.as_slice())?;
+            .map(|blob| {
+                let action = serde_json::from_slice(blob)?;
                 let op = Op {
-                    id: blob.oid.into(),
+                    id,
                     action,
-                    nonce,
                     author: *entry.actor(),
-                    clock: clock.into(),
+                    clock: entry.clock().into(),
                     timestamp: entry.timestamp().into(),
                 };
                 Ok::<_, Self::Error>(op)


### PR DESCRIPTION
By introducing a small limitation: only allowing entries in the change graph to be addressable, instead of individual operations; we drastically simplify the CRDT implementation.

There are four advantages:

1. Op ids are just regular SHA-1s
2. There's no need for relative IDs, ops never refer to other ops within the same commit
3. There's no need for a nonce, since commits can't collide, and neither can op IDs
4. `OpId` can just be an alias of `EntryId`

The disadvantage of course, is that we have to be mindful of how we create op transactions, since each transaction creates an addressable unit. For example, we must not include multiple patch revisions in the same transaction.

**TODO**
* [x] Fix tests