### PR TITLE
cli: use canonical head for patch target

### DIFF
--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -29,7 +29,7 @@ $ rad patch open --message "Define power requirements" --message "See details."
 ✓ Pushing HEAD to storage...
 ✓ Analyzing remotes...
 
-z6MknSL…StBU8Vi/master (f2de534) <- z6MknSL…StBU8Vi/flux-capacitor-power (3e674d1)
+master (f2de534) <- z6MknSL…StBU8Vi/flux-capacitor-power (3e674d1)
 
 1 commit(s) ahead, 0 commit(s) behind
 

--- a/radicle-cli/examples/rad-patch.md
+++ b/radicle-cli/examples/rad-patch.md
@@ -29,7 +29,7 @@ $ rad patch open --message "Define power requirements" --message "See details."
 ✓ Pushing HEAD to storage...
 ✓ Analyzing remotes...
 
-master (f2de534) <- z6MknSL…StBU8Vi/flux-capacitor-power (3e674d1)
+master <- z6MknSL…StBU8Vi/flux-capacitor-power (3e674d1)
 
 1 commit(s) ahead, 0 commit(s) behind
 

--- a/radicle-cli/src/commands/patch/create.rs
+++ b/radicle-cli/src/commands/patch/create.rs
@@ -58,9 +58,8 @@ fn show_patch_commit_info(
 
     term::blank();
     term::info!(
-        "{} ({}) <- {}/{} ({})",
+        "{} <- {}/{} ({})",
         term::format::highlight(target_ref),
-        term::format::secondary(term::format::oid(*target_oid)),
         term::format::dim(term::format::node(node_id)),
         term::format::highlight(branch_name(head_branch)?),
         term::format::secondary(term::format::oid(head_oid)),

--- a/radicle-cli/src/commands/patch/update.rs
+++ b/radicle-cli/src/commands/patch/update.rs
@@ -104,7 +104,7 @@ pub fn run(
 
     push_to_storage(storage, &head_branch, options)?;
 
-    let (_, target_oid) = get_merge_target(&project, storage, &head_branch)?;
+    let (_, target_oid) = get_merge_target(storage, &head_branch)?;
     let mut patches = patch::Patches::open(storage)?;
 
     let patch_id = match patch_id {


### PR DESCRIPTION
Correct assumptions made about how patching work in `rad patch`.  Make the default Patch target a `git ref` in place of a target 'peer'.

Use the canonical head as the git reference.  This is head of the project's master branch which project delegates have concensus on.

The process is simplified by ignoring the case of other delegates having merged the changes.  This would be an rare circumstance which can be handled by the maintainers/contributor for the rare circumstance it happens in.