### PR TITLE
httpd: Serve root handler on `/api/v1` instead of `/api`

### DIFF
--- a/radicle-httpd/src/api.rs
+++ b/radicle-httpd/src/api.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::State;
 use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
 use axum::http::Method;
 use axum::response::{IntoResponse, Json};
@@ -76,12 +75,8 @@ impl Context {
 }
 
 pub fn router(ctx: Context) -> Router {
-    let root_router = Router::new()
-        .route("/", get(root_handler))
-        .with_state(ctx.clone());
-
     Router::new()
-        .merge(root_router)
+        .route("/", get(root_handler))
         .merge(v1::router(ctx))
         .layer(
             CorsLayer::new()
@@ -98,32 +93,13 @@ pub fn router(ctx: Context) -> Router {
         )
 }
 
-async fn root_handler(State(ctx): State<Context>) -> impl IntoResponse {
+async fn root_handler() -> impl IntoResponse {
     let response = json!({
-        "message": "Welcome!",
-        "service": "radicle-httpd",
-        "version": format!("{}-{}", VERSION, env!("GIT_HEAD")),
-        "node": { "id": ctx.profile.public_key },
-        "path": "/",
+        "path": "/api",
         "links": [
             {
-                "href": "/v1/projects",
-                "rel": "projects",
-                "type": "GET"
-            },
-            {
-                "href": "/v1/node",
-                "rel": "node",
-                "type": "GET"
-            },
-            {
-                "href": "/v1/delegates/:did/projects",
-                "rel": "projects",
-                "type": "GET"
-            },
-            {
-                "href": "/v1/stats",
-                "rel": "stats",
+                "href": "/v1",
+                "rel": "v1",
                 "type": "GET"
             }
         ]

--- a/radicle-httpd/src/api/v1.rs
+++ b/radicle-httpd/src/api/v1.rs
@@ -4,12 +4,21 @@ mod projects;
 mod sessions;
 mod stats;
 
+use axum::extract::State;
+use axum::response::{IntoResponse, Json};
+use axum::routing::get;
 use axum::Router;
+use serde_json::json;
 
-use crate::api::Context;
+use crate::api::{Context, VERSION};
 
 pub fn router(ctx: Context) -> Router {
+    let root_router = Router::new()
+        .route("/", get(root_handler))
+        .with_state(ctx.clone());
+
     let routes = Router::new()
+        .merge(root_router)
         .merge(node::router(ctx.clone()))
         .merge(sessions::router(ctx.clone()))
         .merge(delegates::router(ctx.clone()))
@@ -17,4 +26,38 @@ pub fn router(ctx: Context) -> Router {
         .merge(stats::router(ctx));
 
     Router::new().nest("/v1", routes)
+}
+
+async fn root_handler(State(ctx): State<Context>) -> impl IntoResponse {
+    let response = json!({
+        "message": "Welcome!",
+        "service": "radicle-httpd",
+        "version": format!("{}-{}", VERSION, env!("GIT_HEAD")),
+        "node": { "id": ctx.profile.public_key },
+        "path": "/api/v1",
+        "links": [
+            {
+                "href": "/projects",
+                "rel": "projects",
+                "type": "GET"
+            },
+            {
+                "href": "/node",
+                "rel": "node",
+                "type": "GET"
+            },
+            {
+                "href": "/delegates/:did/projects",
+                "rel": "projects",
+                "type": "GET"
+            },
+            {
+                "href": "/stats",
+                "rel": "stats",
+                "type": "GET"
+            }
+        ]
+    });
+
+    Json(response)
 }


### PR DESCRIPTION
```console
$ curl localhost:8080/api | jq
{
  "path": "/api",
  "links": [
    "/v1"
  ]
}

$ curl localhost:8080/api/v1 | jq
{
  "message": "Welcome!",
  "service": "radicle-httpd",
  "version": "0.1.0-b2c2b65",
  "node": {
    "id": "z6MkqgfPWLDruEjqzY5enrrqSSSxpARdFsQK6DWJfBBV9AV4"
  },
  "path": "/api/v1",
  "links": [
    {
      "href": "/projects",
      "rel": "projects",
      "type": "GET"
    },
    {
      "href": "/node",
      "rel": "node",
      "type": "GET"
    },
    {
      "href": "/delegates/:did/projects",
      "rel": "projects",
      "type": "GET"
    },
    {
      "href": "/stats",
      "rel": "stats",
      "type": "GET"
    }
  ]
}
```