### PR TITLE
node: Fetch missing inventory 

### DIFF
--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -71,8 +71,6 @@ fn rad_issue() {
 
     // Setup a test repository.
     fixtures::repository(&working);
-    // Set a fixed commit time.
-    env::set_var(radicle_cob::git::RAD_COMMIT_TIME, "1671125284");
 
     test("examples/rad-init.md", &working, Some(home), []).unwrap();
     test("examples/rad-issue.md", &working, Some(home), []).unwrap();

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -145,7 +145,7 @@ impl Storage {
 
             // For performance reasons, we don't do a full repository check here.
             if let Err(e) = repo.head() {
-                log::error!(target: "storage", "Repository {rid} is corrupted: looking up head: {e}");
+                log::warn!(target: "storage", "Repository {rid} is invalid: looking up head: {e}");
                 continue;
             }
             repos.push(rid);


### PR DESCRIPTION
Periodically, make sure we try to fetch inventory that is tracked
but missing from local storage.

We decide not to fetch immediately on `TrackRepo`, as this limits
the command's flexibility. For example, when `rad clone` is used,
we want to be able to fetch manually after tracking.

Closes #364 