### PR TITLE
node: Rename `tracked_repo` -> `repo_policies`

### DIFF
--- a/radicle-cli/src/commands/node/tracking.rs
+++ b/radicle-cli/src/commands/node/tracking.rs
@@ -18,7 +18,7 @@ fn print_repos(node: &Node) -> anyhow::Result<()> {
     let mut t = term::Table::new(term::table::TableOptions::default());
     t.push(["RID", "Scope", "Policy"]);
     t.push(["---", "-----", "------"]);
-    for tracking::Repo { id, scope, policy } in node.tracked_repos()? {
+    for tracking::Repo { id, scope, policy } in node.repo_policies()? {
         t.push([
             term::format::highlight(id.to_string()),
             term::format::secondary(scope.to_string()),
@@ -33,7 +33,7 @@ fn print_nodes(node: &Node) -> anyhow::Result<()> {
     let mut t = term::Table::new(term::table::TableOptions::default());
     t.push(["DID", "Alias", "Policy"]);
     t.push(["---", "-----", "------"]);
-    for tracking::Node { id, alias, policy } in node.tracked_nodes()? {
+    for tracking::Node { id, alias, policy } in node.node_policies()? {
         t.push([
             term::format::highlight(Did::from(id).to_string()),
             match alias {

--- a/radicle-node/src/control.rs
+++ b/radicle-node/src/control.rs
@@ -131,7 +131,7 @@ fn command<H: Handle<Error = runtime::HandleError>>(
                 }
             }
         }
-        CommandName::TrackedRepos => match handle.tracked_repos() {
+        CommandName::RepoPolicies => match handle.repo_policies() {
             Ok(ts) => {
                 for t in ts.into_iter() {
                     serde_json::to_writer(&mut writer, &t)?;
@@ -171,7 +171,7 @@ fn command<H: Handle<Error = runtime::HandleError>>(
                 }
             }
         }
-        CommandName::TrackedNodes => match handle.tracked_nodes() {
+        CommandName::NodePolicies => match handle.node_policies() {
             Ok(ts) => {
                 for t in ts.into_iter() {
                     serde_json::to_writer(&mut writer, &t)?;

--- a/radicle-node/src/runtime/handle.rs
+++ b/radicle-node/src/runtime/handle.rs
@@ -111,8 +111,8 @@ impl<G: Signer + Ecdh + 'static> radicle::node::Handle for Handle<G> {
     type Error = Error;
 
     type Routing = chan::Receiver<(Id, NodeId)>;
-    type TrackedRepos = chan::Receiver<tracking::Repo>;
-    type TrackedNodes = chan::Receiver<tracking::Node>;
+    type RepoPolicies = chan::Receiver<tracking::Repo>;
+    type NodePolicies = chan::Receiver<tracking::Node>;
 
     fn is_running(&self) -> bool {
         true
@@ -136,10 +136,10 @@ impl<G: Signer + Ecdh + 'static> radicle::node::Handle for Handle<G> {
         receiver.recv().map_err(Error::from)
     }
 
-    fn tracked_repos(&self) -> Result<Self::TrackedRepos, Self::Error> {
+    fn repo_policies(&self) -> Result<Self::RepoPolicies, Self::Error> {
         let (sender, receiver) = chan::unbounded();
         let query: Arc<QueryState> = Arc::new(move |state| {
-            for t in state.tracked_repos()? {
+            for t in state.repo_policies()? {
                 if sender.send(t).is_err() {
                     break;
                 }
@@ -153,10 +153,10 @@ impl<G: Signer + Ecdh + 'static> radicle::node::Handle for Handle<G> {
         Ok(receiver)
     }
 
-    fn tracked_nodes(&self) -> Result<Self::TrackedNodes, Self::Error> {
+    fn node_policies(&self) -> Result<Self::NodePolicies, Self::Error> {
         let (sender, receiver) = chan::unbounded();
         let query: Arc<QueryState> = Arc::new(move |state| {
-            for t in state.tracked_nodes()? {
+            for t in state.node_policies()? {
                 if sender.send(t).is_err() {
                     break;
                 }

--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -1452,9 +1452,9 @@ pub trait ServiceState {
     /// Get reference to routing table.
     fn routing(&self) -> &dyn routing::Store;
     /// Get the tracked repos.
-    fn tracked_repos(&self) -> Result<Vec<tracking::Repo>, tracking::Error>;
+    fn repo_policies(&self) -> Result<Vec<tracking::Repo>, tracking::Error>;
     /// Get the tracked nodes.
-    fn tracked_nodes(&self) -> Result<Vec<tracking::Node>, tracking::Error>;
+    fn node_policies(&self) -> Result<Vec<tracking::Node>, tracking::Error>;
 }
 
 impl<R, A, S, G> ServiceState for Service<R, A, S, G>
@@ -1491,11 +1491,11 @@ where
         &self.routing
     }
 
-    fn tracked_repos(&self) -> Result<Vec<tracking::Repo>, tracking::Error> {
+    fn repo_policies(&self) -> Result<Vec<tracking::Repo>, tracking::Error> {
         Ok(self.tracking.repo_entries()?.collect())
     }
 
-    fn tracked_nodes(&self) -> Result<Vec<tracking::Node>, tracking::Error> {
+    fn node_policies(&self) -> Result<Vec<tracking::Node>, tracking::Error> {
         Ok(self.tracking.node_entries()?.collect())
     }
 }

--- a/radicle-node/src/test/handle.rs
+++ b/radicle-node/src/test/handle.rs
@@ -21,8 +21,8 @@ impl radicle::node::Handle for Handle {
     type Error = HandleError;
     type Sessions = service::Sessions;
     type Routing = Vec<(Id, NodeId)>;
-    type TrackedRepos = Vec<tracking::Repo>;
-    type TrackedNodes = Vec<tracking::Node>;
+    type RepoPolicies = Vec<tracking::Repo>;
+    type NodePolicies = Vec<tracking::Node>;
 
     fn is_running(&self) -> bool {
         true
@@ -40,7 +40,7 @@ impl radicle::node::Handle for Handle {
         Ok(FetchResult::from(Ok::<Vec<RefUpdate>, Self::Error>(vec![])))
     }
 
-    fn tracked_repos(&self) -> Result<Self::TrackedRepos, Self::Error> {
+    fn repo_policies(&self) -> Result<Self::RepoPolicies, Self::Error> {
         Ok(self
             .tracking_repos
             .iter()
@@ -53,7 +53,7 @@ impl radicle::node::Handle for Handle {
             .collect())
     }
 
-    fn tracked_nodes(&self) -> Result<Self::TrackedNodes, Self::Error> {
+    fn node_policies(&self) -> Result<Self::NodePolicies, Self::Error> {
         Ok(self
             .tracking_nodes
             .iter()


### PR DESCRIPTION
I was finding the current naming misleading, as the returned entries could be for blocked repos/nodes.