### PR TITLE
httpd: Basic alias support for git

### DIFF
--- a/radicle-httpd/src/error.rs
+++ b/radicle-httpd/src/error.rs
@@ -4,6 +4,10 @@ use axum::response::{IntoResponse, Response};
 /// Errors relating to the HTTP backend.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// The entity was not found.
+    #[error("not found")]
+    NotFound,
+
     /// I/O error.
     #[error("i/o error: {0}")]
     Io(#[from] std::io::Error),
@@ -47,6 +51,7 @@ impl Error {
             Error::ServiceUnavailable(_) => http::StatusCode::SERVICE_UNAVAILABLE,
             Error::InvalidId => http::StatusCode::NOT_FOUND,
             Error::Id(_) => http::StatusCode::NOT_FOUND,
+            Error::NotFound => http::StatusCode::NOT_FOUND,
             _ => http::StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/radicle-httpd/src/lib.rs
+++ b/radicle-httpd/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::too_many_arguments)]
 pub mod error;
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::process::Command;
 use std::str;
@@ -14,6 +15,7 @@ use axum::body::{Body, BoxBody, HttpBody};
 use axum::http::{Request, Response};
 use axum::middleware;
 use axum::Router;
+use radicle::identity::Id;
 use tower_http::trace::TraceLayer;
 
 use tracing_extra::{tracing_middleware, ColoredStatus, Paint, RequestId, TracingInfo};
@@ -28,6 +30,7 @@ mod tracing_extra;
 
 #[derive(Debug, Clone)]
 pub struct Options {
+    pub aliases: HashMap<String, Id>,
     pub listen: SocketAddr,
 }
 
@@ -48,7 +51,7 @@ pub async fn run(options: Options) -> anyhow::Result<()> {
 
     let ctx = api::Context::new(profile.clone());
     let api_router = api::router(ctx);
-    let git_router = git::router(profile.clone());
+    let git_router = git::router(profile.clone(), options.aliases);
     let raw_router = raw::router(profile);
 
     tracing::info!("listening on http://{}", options.listen);

--- a/radicle-httpd/src/main.rs
+++ b/radicle-httpd/src/main.rs
@@ -1,5 +1,6 @@
-use std::process;
+use std::{collections::HashMap, process};
 
+use radicle::prelude::Id;
 use radicle_httpd as httpd;
 use tracing::dispatcher::Dispatch;
 
@@ -49,6 +50,7 @@ fn parse_options() -> Result<httpd::Options, lexopt::Error> {
 
     let mut parser = lexopt::Parser::from_env();
     let mut listen = None;
+    let mut aliases = HashMap::new();
 
     while let Some(arg) = parser.next()? {
         match arg {
@@ -56,14 +58,21 @@ fn parse_options() -> Result<httpd::Options, lexopt::Error> {
                 let addr = parser.value()?.parse()?;
                 listen = Some(addr);
             }
+            Long("alias") | Short('a') => {
+                let alias: String = parser.value()?.parse()?;
+                let id: Id = parser.value()?.parse()?;
+
+                aliases.insert(alias, id);
+            }
             Long("help") => {
-                println!("usage: radicle-httpd [--listen <addr>]");
+                println!("usage: radicle-httpd [--listen <addr>] [--alias <name> <rid>]..");
                 process::exit(0);
             }
             _ => return Err(arg.unexpected()),
         }
     }
     Ok(httpd::Options {
+        aliases,
         listen: listen.unwrap_or_else(|| ([0, 0, 0, 0], 8080).into()),
     })
 }

--- a/radicle-httpd/src/test.rs
+++ b/radicle-httpd/src/test.rs
@@ -23,6 +23,7 @@ use radicle_crypto::test::signer::MockSigner;
 
 use crate::api::{auth, Context};
 
+pub const RID: &str = "rad:z4FucBZHZMCsxTyQE1dfE2YR59Qbp";
 pub const HEAD: &str = "1e978d19f251cd9821d9d9a76d1bd436bf0690d5";
 pub const HEAD_1: &str = "f604ce9fd5b7cc77b7609beda45ea8760bee78f7";
 pub const PATCH_ID: &str = "6ec9a764a888576abc7e582dbf82a31e23a9789d";


### PR DESCRIPTION
Allows cloning via git using an alias instead of the full RID.

Eg. `git clone https://seed.radicle.xyz/heartwood.git`