### PR TITLE
fix namespaces_for in scope::Trusted scenarios and its test

### DIFF
--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -496,6 +496,15 @@ fn test_replication_via_seed() {
         .rad("track", &[&bob.id.to_human()], working.join("alice"))
         .unwrap();
 
+    // Track nodes as the default scope is Trusted.
+    alice
+        .handle
+        .track_node(bob.id, Some("bob".to_string()))
+        .unwrap();
+    bob.handle
+        .track_node(alice.id, Some("alice".to_string()))
+        .unwrap();
+
     alice.routes_to(&[(rid, alice.id), (rid, seed.id)]);
     seed.routes_to(&[(rid, alice.id), (rid, seed.id)]);
     bob.routes_to(&[(rid, alice.id), (rid, seed.id)]);

--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -1103,7 +1103,7 @@ where
                 }
                 debug!(target: "service", "Fetch accepted for {rid} from {remote}..");
 
-                let namespaces = match self.tracking.namespaces_for(&self.storage, &rid) {
+                let namespaces = match self.tracking.namespaces_for(&self.storage, &rid, remote) {
                     Ok(ns) => ns,
                     Err(err) => {
                         if let Some(resp) = self.fetch_reqs.get(&rid) {

--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -991,6 +991,15 @@ fn test_push_and_pull() {
         sender,
     ));
 
+    // Bob tracks Alice the node.
+    // This is needed as the default scope is `Trusted`.
+    let (sender, _) = chan::bounded(1);
+    bob.command(service::Command::TrackNode(
+        alice.id(),
+        Some("alice".to_string()),
+        sender,
+    ));
+
     // Eve tracks Alice's project.
     let (sender, _) = chan::bounded(1);
     eve.command(service::Command::TrackRepo(

--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -223,7 +223,6 @@ fn test_dont_fetch_owned_refs() {
 }
 
 #[test]
-#[ignore = "failing"]
 fn test_fetch_trusted_remotes() {
     logger::init(log::Level::Debug);
 

--- a/radicle-node/src/worker.rs
+++ b/radicle-node/src/worker.rs
@@ -142,7 +142,7 @@ impl<G: Signer + Ecdh + 'static> Worker<G> {
                 if let Err(err) = &result {
                     log::error!(target: "worker", "Fetch error: {err}");
                 } else if let Err(err) = pktline::done(&mut session) {
-                    log::error!(target: "worker", "Fetch error: {err}");
+                    log::error!(target: "worker", "pktline::done error: {err}");
                 }
                 (session, result)
             }


### PR DESCRIPTION
I noticed that [`test_fetch_trusted_remotes`](https://github.com/radicle-dev/heartwood/blob/f8aa1daedb391069847c66e14b2da6cc2e5669ae/radicle-node/src/tests/e2e.rs#L225-L227) was not working (ignored currently), and then I looked into it.  Hence this fix. 

Also updated other related tests.

This fix is more or less best effort and a learning experience for me. I felt there should be more refactoring we can do to improve this.