### PR TITLE
node: Fail fast when repository can't be read

### DIFF
--- a/radicle-node/src/service/tracking.rs
+++ b/radicle-node/src/service/tracking.rs
@@ -31,7 +31,7 @@ pub enum NamespacesError {
         #[source]
         err: Error,
     },
-    #[error("Failed to get delegate nodes for {rid}")]
+    #[error("Failed to get delegates for {rid}")]
     FailedDelegates {
         rid: Id,
         #[source]

--- a/radicle/src/storage.rs
+++ b/radicle/src/storage.rs
@@ -29,7 +29,7 @@ pub type BranchName = git::RefString;
 pub type Inventory = Vec<Id>;
 
 /// Describes one or more namespaces.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub enum Namespaces {
     /// All namespaces.
     #[default]

--- a/radicle/src/test/storage.rs
+++ b/radicle/src/test/storage.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use git_ref_format as fmt;
@@ -59,7 +60,7 @@ impl ReadStorage for MockStorage {
         let doc = self
             .inventory
             .get(&rid)
-            .expect("Mockstorage::repository: missing doc");
+            .ok_or_else(|| Error::Io(io::Error::from(io::ErrorKind::NotFound)))?;
         Ok(MockRepository {
             id: rid,
             doc: doc.clone(),


### PR DESCRIPTION
It's not a good idea to have fallible operations run after `FetchOk`
is received, since there's no easy way to communicate the error
to the remote at that point. Hence, we compute namespaces earlier
in the process, and store the namespaces in the session.