### PR TITLE
node: Fix potential protocol mismatch on fetch

### DIFF
--- a/radicle-node/src/service.rs
+++ b/radicle-node/src/service.rs
@@ -385,6 +385,8 @@ where
                 .repo_policies()?
                 .filter_map(|t| (t.policy == tracking::Policy::Track).then_some(t.id)),
         );
+        // Start periodic tasks.
+        self.reactor.wakeup(IDLE_INTERVAL);
 
         Ok(())
     }

--- a/radicle-node/src/test/peer.rs
+++ b/radicle-node/src/test/peer.rs
@@ -22,7 +22,6 @@ use crate::storage::git::transport::remote;
 use crate::storage::Inventory;
 use crate::storage::{RemoteId, WriteStorage};
 use crate::test::arbitrary;
-use crate::test::assert_matches;
 use crate::test::simulator;
 use crate::test::storage::MockStorage;
 use crate::Link;
@@ -281,7 +280,9 @@ where
         self.service
             .command(Command::Connect(remote_id, remote_addr.clone()));
 
-        assert_matches!(self.outbox().next(), Some(Io::Connect { .. }));
+        self.outbox()
+            .find(|o| matches!(o, Io::Connect { .. }))
+            .unwrap();
 
         self.service.attempted(remote_id, &remote_addr);
         self.service.connected(remote_id, Link::Outbound);

--- a/radicle-node/src/tests.rs
+++ b/radicle-node/src/tests.rs
@@ -218,7 +218,7 @@ fn test_persistent_peer_connect() {
     let mut outbox = alice.outbox();
     assert_matches!(outbox.next(), Some(Io::Connect(a, _)) if a == bob.id());
     assert_matches!(outbox.next(), Some(Io::Connect(a, _)) if a == eve.id());
-    assert_matches!(outbox.next(), None);
+    assert_matches!(outbox.find(|o| matches!(o, Io::Connect { .. })), None);
 }
 
 #[test]

--- a/radicle-node/src/wire/message.rs
+++ b/radicle-node/src/wire/message.rs
@@ -365,7 +365,7 @@ impl wire::Encode for ZeroBytes {
     fn encode<W: io::Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
         let mut n = (self.len() as u16).encode(writer)?;
         for _ in 0..self.len() {
-            n += 0u8.encode(writer)?
+            n += 0u8.encode(writer)?;
         }
         Ok(n)
     }

--- a/radicle-node/src/worker.rs
+++ b/radicle-node/src/worker.rs
@@ -315,7 +315,7 @@ impl<G: Signer + Ecdh + 'static> Worker<G> {
         loop {
             // Read from the daemon and write to the stream.
             if let Err(e) = daemon_r.pipe(stream_w, &mut buffer) {
-                // This is the expected error when the remote disconnects.
+                // This is the expected error when the daemon disconnects.
                 if e.kind() == io::ErrorKind::UnexpectedEof {
                     log::debug!(target: "worker", "Daemon closed the git connection for {}", fetch.rid);
                     return Err(e.into());
@@ -398,7 +398,7 @@ impl Pool {
     }
 }
 
-mod pktline {
+pub mod pktline {
     use std::io;
     use std::io::Read;
     use std::ops::ControlFlow;


### PR DESCRIPTION
It's possible that the daemon or stream closes the git connection without reading the final `done` packet. If this is the case, we try to read it after either of the connections is closed.

This may potentially mitigate the issue where the node then receives the `done` packet while in gossip mode, and disconnects the remote for misbehavior.