### PR TITLE
radicle-httpd: Add timestamp to revisions api::json

### DIFF
--- a/radicle-httpd/src/api/json.rs
+++ b/radicle-httpd/src/api/json.rs
@@ -115,6 +115,7 @@ pub(crate) fn patch(id: PatchId, patch: Patch) -> Value {
             json!({
                 "id": id,
                 "description": rev.description(),
+                "timestamp": rev.timestamp,
                 "reviews": rev.reviews().collect::<Vec<_>>(),
             })
         }).collect::<Vec<_>>(),

--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -1335,6 +1335,7 @@ mod routes {
                     {
                         "id": PATCH_ID,
                         "description": "",
+                        "timestamp": 1671125284,
                         "reviews": [],
                     }
                 ],
@@ -1362,6 +1363,7 @@ mod routes {
                     {
                         "id": PATCH_ID,
                         "description": "",
+                        "timestamp": 1671125284,
                         "reviews": [],
                     }
                 ],
@@ -1432,6 +1434,7 @@ mod routes {
                     {
                         "id": CREATED_PATCH_ID,
                         "description": "",
+                        "timestamp": 1671125284,
                         "reviews": [],
                     }
                 ],


### PR DESCRIPTION
Allows the web client to show timestamps for when a patch had its first revision, and to allow timestamps for the following revisions to show.