### PR TITLE
Use camelCase in query params

### DIFF
--- a/radicle-httpd/src/api.rs
+++ b/radicle-httpd/src/api.rs
@@ -109,7 +109,7 @@ async fn root_handler() -> impl IntoResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 pub struct PaginationQuery {
     pub page: Option<usize>,
     pub per_page: Option<usize>,

--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -114,7 +114,7 @@ async fn project_handler(State(ctx): State<Context>, Path(id): Path<Id>) -> impl
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 pub struct CommitsQueryString {
     pub parent: Option<String>,
     pub since: Option<i64>,


### PR DESCRIPTION
It's more ergonomic to consume in JS/TS. 🤷 