### PR TITLE
Enable `rad merge` to work on concurrently updated patches

### DIFF
--- a/radicle-cli/examples/workflow/5-patching-maintainer.md
+++ b/radicle-cli/examples/workflow/5-patching-maintainer.md
@@ -54,3 +54,36 @@ a07ef77 R1 (27857ec) -> R2 (f6484e0)
 
 ✓ Patch a07ef77 updated to 737dc47d9eba730c5db8a8e33c41c7955f9093de
 ```
+
+Great, all fixed up, lets merge the code.
+
+```
+$ git checkout master
+Your branch is up to date with 'rad/master'.
+$ rad merge 737dc47d9eba730c5db8a8e33c41c7955f9093de
+Merging a07ef77 R2 (f6484e0) by did:key:z6Mkt67GdsW7715MEfRuP4pSZxJRJh6kj6Y48WRqVv4N1tRk into master (f2de534) via fast-forward...
+Running `git merge --ff-only f6484e0f43e48a8983b9b39bf9bd4cd889f1d520`...
+Updating f2de534..f6484e0
+Fast-forward
+ README.md       | 0
+ REQUIREMENTS.md | 0
+ 2 files changed, 0 insertions(+), 0 deletions(-)
+ create mode 100644 README.md
+ create mode 100644 REQUIREMENTS.md
+✓ Updated master f2de534 -> f6484e0 via fast-forward
+✓ Patch state updated, use `rad push` to publish
+```
+
+The patch is now merged and closed :).
+
+```
+$ rad patch
+╭───────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Define power requirements a07ef77 R2 f6484e0 (flux-capacitor-power, master) ahead 3, behind 0 │
+├───────────────────────────────────────────────────────────────────────────────────────────────┤
+│ ● opened by did:key:z6Mkt67GdsW7715MEfRuP4pSZxJRJh6kj6Y48WRqVv4N1tRk 3 months ago             │
+│ ↑ updated to a07ef7743a32a2e902672ea3526d1db6ee08108a (3e674d1) 3 months ago                  │
+│ ↑ updated to 4f15eb5c994edd0bb6be29cb4801aa74308cc628 (27857ec) 3 months ago                  │
+│ ✓ merged by did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi (you) 3 months ago       │
+╰───────────────────────────────────────────────────────────────────────────────────────────────╯
+```

--- a/radicle-cli/src/git.rs
+++ b/radicle-cli/src/git.rs
@@ -11,7 +11,6 @@ use std::str::FromStr;
 use anyhow::anyhow;
 use anyhow::Context as _;
 
-use radicle::cob::ObjectId;
 use radicle::crypto::ssh;
 use radicle::git;
 use radicle::git::raw as git2;
@@ -39,10 +38,13 @@ impl Rev {
         &self.0
     }
 
-    /// Resolve the revision to an [`ObjectId`].
-    pub fn resolve(&self, repo: &git2::Repository) -> Result<ObjectId, git2::Error> {
+    /// Resolve the revision to an [`From<git2::Oid>`].
+    pub fn resolve<T>(&self, repo: &git2::Repository) -> Result<T, git2::Error>
+    where
+        T: From<git2::Oid>,
+    {
         let object = repo.revparse_single(self.as_str())?;
-        Ok(ObjectId::from(object.id()))
+        Ok(object.id().into())
     }
 }
 

--- a/radicle-cob/src/history/entry.rs
+++ b/radicle-cob/src/history/entry.rs
@@ -10,6 +10,7 @@ use nonempty::NonEmpty;
 use radicle_crypto::PublicKey;
 use serde::{Deserialize, Serialize};
 
+use crate::object;
 use crate::pruning_fold;
 
 /// Entry contents.
@@ -57,6 +58,12 @@ impl From<Oid> for EntryId {
 impl From<EntryId> for Oid {
     fn from(EntryId(id): EntryId) -> Self {
         id
+    }
+}
+
+impl From<&EntryId> for object::ObjectId {
+    fn from(EntryId(id): &EntryId) -> Self {
+        id.into()
     }
 }
 

--- a/radicle-term/src/io.rs
+++ b/radicle-term/src/io.rs
@@ -124,7 +124,7 @@ pub fn indented(msg: impl fmt::Display) {
 }
 
 pub fn subcommand(msg: impl fmt::Display) {
-    println!("{} {}", style("$").dim(), style(msg).dim());
+    println!("{}", style(format!("Running `{msg}`...")).dim());
 }
 
 pub fn warning(warning: &str) {


### PR DESCRIPTION
`rad merge` originally takes an optional revision number to define which version of a patch to merge.  The problem is a patch can be updated concurrently, multiple versions of the patch could exist with the same version number.

Therefor use the patch's globally unique revision -id- instead of its index number.

Related to https://github.com/radicle-dev/heartwood/issues/148