### PR TITLE
radicle: Fix profile::canonicalize_home test on MacOS

### DIFF
--- a/radicle/src/profile.rs
+++ b/radicle/src/profile.rs
@@ -227,6 +227,7 @@ impl Home {
 #[cfg(test)]
 mod test {
     use std::fs;
+    use std::path::Path;
 
     use super::Home;
 
@@ -242,7 +243,7 @@ mod test {
         fs::create_dir_all(path.clone()).unwrap();
 
         let last = tmp.path().components().last().unwrap();
-        let home = Home::new(
+        let mut home = Home::new(
             tmp.path()
                 .join("..")
                 .join(last)
@@ -250,6 +251,11 @@ mod test {
                 .join("Radicle"),
         )
         .unwrap();
+        if cfg!(target_os = "macos") {
+            home.path =
+                Path::new("/").join(home.path.strip_prefix("/private").unwrap_or(&home.path))
+        };
+
         assert_eq!(home.path, path);
     }
 }


### PR DESCRIPTION
On MacOS the following error appears when running the test suite

```
thread 'profile::test::canonicalize_home' panicked at 'assertion failed: `(left == right)`
  left: `"/private/var/folders/r9/dcp4ksl90dnfj2kqg7g7nbd40000gn/T/.tmpuewkuK/Home/Radicle"`,
 right: `"/var/folders/r9/dcp4ksl90dnfj2kqg7g7nbd40000gn/T/.tmpuewkuK/Home/Radicle"`', radicle/src/profile.rs:253:9
 ```

To make the tests pass we should strip the `/private` prefix on MacOS, if it exists.
It shouldn't be an issue since MacOS provides a `/var` symlink to mimic Unix behaviour