### PR TITLE
httpd: Add `content` property to `CodeLocation` in serialization

### DIFF
--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -2089,7 +2089,8 @@ mod routes {
           "inline": [
             {
               "location": {
-                "blob": HEAD,
+                "blob": "82eb77880c693655bce074e3dbbd9fa711dc018b",
+                "path": "./README.md",
                 "commit": HEAD,
                 "lines": {
                     "start": 1,
@@ -2148,7 +2149,8 @@ mod routes {
                         "inline": [
                           {
                             "location": {
-                              "blob": HEAD,
+                              "blob": "82eb77880c693655bce074e3dbbd9fa711dc018b",
+                              "path": "./README.md",
                               "commit": HEAD,
                               "lines": {
                                 "start": 1,

--- a/radicle/src/cob/patch.rs
+++ b/radicle/src/cob/patch.rs
@@ -2,6 +2,7 @@
 use std::fmt;
 use std::ops::Deref;
 use std::ops::Range;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use once_cell::sync::Lazy;
@@ -466,6 +467,8 @@ impl fmt::Display for Verdict {
 pub struct CodeLocation {
     /// File being commented on.
     pub blob: git::Oid,
+    /// Path of file being commented on.
+    pub path: PathBuf,
     /// Commit commented on.
     pub commit: git::Oid,
     /// Line range commented on.
@@ -480,12 +483,20 @@ impl PartialOrd for CodeLocation {
 
 impl Ord for CodeLocation {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (&self.blob, &self.commit, &self.lines.start, &self.lines.end).cmp(&(
-            &other.blob,
-            &other.commit,
-            &other.lines.start,
-            &other.lines.end,
-        ))
+        (
+            &self.blob,
+            &self.path,
+            &self.commit,
+            &self.lines.start,
+            &self.lines.end,
+        )
+            .cmp(&(
+                &other.blob,
+                &other.path,
+                &other.commit,
+                &other.lines.start,
+                &other.lines.end,
+            ))
     }
 }
 


### PR DESCRIPTION
For the web client to be able to show file content based on a Oid we need to provide the web client with the file in question.

~~It gets a bit messy IMO, since we need to drill down until we get to the `CodeLocation` to be able to serialize the Blob Oid, into its content, adding a new field..~~

~~I think this would be nicer if instead or additionally to passing a Blob Id we store the file path in the `CodeLocation` struct, and then query the `/raw` endpoint for the files content.~~