### PR TITLE
httpd: Add `CorsLayer` to `/raw` endpoint

### DIFF
--- a/radicle-httpd/src/raw.rs
+++ b/radicle-httpd/src/raw.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::State;
-use axum::http::{header, StatusCode};
+use axum::http::{header, Method, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
 use hyper::HeaderMap;
+use tower_http::cors;
 
 use radicle::prelude::Id;
 use radicle::profile::Profile;
@@ -93,6 +95,13 @@ pub fn router(profile: Arc<Profile>) -> Router {
     Router::new()
         .route("/:project/:sha/*path", get(file_handler))
         .with_state(profile)
+        .layer(
+            cors::CorsLayer::new()
+                .max_age(Duration::from_secs(86400))
+                .allow_origin(cors::Any)
+                .allow_methods([Method::GET])
+                .allow_headers([header::CONTENT_TYPE]),
+        )
 }
 
 async fn file_handler(


### PR DESCRIPTION
This PR adds the following headers to the `/raw` endpoint, they are similar to the `api` router.
Most importantly we need to `Access-Control-Allow-Origin` so we can query the endpoint from the web client.

- `Access-Control-Max-Age` of 24 hours, so we cache some of the requests.
  - We should probably implement something that caches even longer
- `Access-Control-Allow-Origin` so we can do `fetch` from the web client to this endpoint without cors issues
- `Access-Control-Allow-Methods` so we limit the allowed methods to GET
- `Access-Control-Allow-Methods` limit to `content-type` so we can require application/json, etc.