### PR TITLE
httpd: Add reactions to issue and patch json output

### DIFF
--- a/radicle-httpd/src/api/v1/projects.rs
+++ b/radicle-httpd/src/api/v1/projects.rs
@@ -1523,6 +1523,24 @@ mod routes {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json().await, json!({ "success": true }));
 
+        let body = serde_json::to_vec(&json!({
+          "type": "thread",
+          "action": {
+            "type": "react",
+            "to": "9685b141c2e939c3d60f8ca34f8c7bf01a609af1",
+            "reaction": "🚀",
+            "active": true,
+          }
+        }))
+        .unwrap();
+        patch(
+            &app,
+            format!("/projects/{CONTRIBUTOR_RID}/issues/{CONTRIBUTOR_ISSUE_ID}"),
+            Some(Body::from(body)),
+            Some(SESSION_ID.to_string()),
+        )
+        .await;
+
         let response = get(
             &app,
             format!("/projects/{CONTRIBUTOR_RID}/issues/{CONTRIBUTOR_ISSUE_ID}"),
@@ -1536,11 +1554,11 @@ mod routes {
               "author": {
                 "id": CONTRIBUTOR_DID,
               },
-              "assignees": [],
               "title": "Issue #1",
               "state": {
                 "status": "open",
               },
+              "assignees": [],
               "discussion": [
                 {
                   "id": ISSUE_DISCUSSION_ID,
@@ -1558,7 +1576,12 @@ mod routes {
                     "id": CONTRIBUTOR_DID,
                   },
                   "body": "This is first-level comment",
-                  "reactions": [],
+                  "reactions": [
+                    [
+                      "z6Mkk7oqY4pPxhMmGEotDYsFo97vhCj85BLY1H256HrJmjN8",
+                      "🚀",
+                    ],
+                  ],
                   "timestamp": TIMESTAMP,
                   "replyTo": null,
                 },

--- a/radicle/src/cob/issue.rs
+++ b/radicle/src/cob/issue.rs
@@ -80,10 +80,15 @@ impl State {
 /// Issue state. Accumulates [`Action`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Issue {
+    /// Actors assigned to this issue.
     assignees: LWWSet<ActorId>,
+    /// Title of the issue.
     title: LWWReg<Max<String>, clock::Lamport>,
+    /// Current state of the issue.
     state: LWWReg<Max<State>, clock::Lamport>,
+    /// Associated tags.
     tags: LWWSet<Tag>,
+    /// Discussion around this issue.
     thread: Thread,
 }
 
@@ -193,6 +198,10 @@ impl Issue {
 
     pub fn description(&self) -> Option<&str> {
         self.thread.comments().next().map(|(_, c)| c.body())
+    }
+
+    pub fn thread(&self) -> &Thread {
+        &self.thread
     }
 
     pub fn comments(&self) -> impl Iterator<Item = (&CommentId, &thread::Comment)> {


### PR DESCRIPTION
This PR adds the reactions array to `json::issue` and `json::patch` output.

**Remarks**
- @FintanH I made the `cob::issue::Issue` properties public, similar to `cob::patch::Patch`, if we don't want to do that, maybe I can find a workaround to get the `thread` property some other way..