### PR TITLE
Reduce pub accessors in patch and issue cob structs

### DIFF
--- a/radicle-cli/src/commands/merge.rs
+++ b/radicle-cli/src/commands/merge.rs
@@ -166,7 +166,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     // Analyze merge
     //
     let patch_commit = repo
-        .find_annotated_commit(revision.oid.into())
+        .find_annotated_commit(revision.head().into())
         .context("patch head not found in local repository")?;
     let (merge, _merge_pref) = repo.merge_analysis(&[&patch_commit])?;
 
@@ -180,7 +180,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         //
         // Let's check if there are potential merge conflicts.
         let our_commit = head.peel_to_commit()?;
-        let their_commit = repo.find_commit(revision.oid.into())?;
+        let their_commit = repo.find_commit(revision.head().into())?;
 
         let index = repo
             .merge_commits(&our_commit, &their_commit, None)
@@ -207,7 +207,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         anyhow::bail!(
             "no merge is possible between {} and {}",
             head_oid,
-            revision.oid
+            revision.head()
         );
     };
 
@@ -226,7 +226,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         term::format::bold("Merging"),
         term::format::tertiary(term::format::cob(&patch_id)),
         term::format::dim(format!("R{revision_ix}")),
-        term::format::parens(term::format::secondary(term::format::oid(revision.oid))),
+        term::format::parens(term::format::secondary(term::format::oid(revision.head()))),
         term::format::tertiary(patch.author().id),
         term::format::highlight(branch),
         term::format::parens(term::format::secondary(term::format::oid(head_oid))),
@@ -245,7 +245,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
             merge_commit(&repo, patch_id, &patch_commit, &patch, signer.public_key())?;
         }
         MergeStyle::FastForward => {
-            fast_forward(&repo, &revision.oid)?;
+            fast_forward(&repo, &revision.head())?;
         }
     }
 
@@ -253,7 +253,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         "Updated {} {} -> {} via {}",
         term::format::highlight(branch),
         term::format::secondary(term::format::oid(head_oid)),
-        term::format::secondary(term::format::oid(revision.oid)),
+        term::format::secondary(term::format::oid(revision.head())),
         merge_style_pretty
     );
 

--- a/radicle-cli/src/commands/patch/checkout.rs
+++ b/radicle-cli/src/commands/patch/checkout.rs
@@ -56,7 +56,7 @@ fn find_patch_commit<'a>(
             let (_, rev) = patch
                 .latest()
                 .ok_or(anyhow!("patch does not have any revisions"))?;
-            let author = **rev.author.id();
+            let author = *rev.author().id();
             let remote = stored.remote(&author)?;
 
             // Find a ref in storage that points to our patch, so that we can fetch the patch
@@ -70,7 +70,7 @@ fn find_patch_commit<'a>(
                 &RefString::try_from(author.to_string())?,
                 patch_branch,
             );
-            let url = git::Url::from(stored.id).with_namespace(author);
+            let url = git::Url::from(stored.id).with_namespace(*author);
 
             // Fetch only the ref pointing to the patch revision.
             working.remote_anonymous(url.to_string().as_str())?.fetch(

--- a/radicle-cli/src/commands/patch/common.rs
+++ b/radicle-cli/src/commands/patch/common.rs
@@ -185,7 +185,7 @@ pub fn find_unmerged_with_base(
     for (id, patch, clock) in proposed {
         let (_, rev) = patch.latest().unwrap();
 
-        if !rev.merges.is_empty() {
+        if !rev.merges().count() == 0 {
             continue;
         }
         if **patch.head() == patch_head {

--- a/radicle-cli/src/commands/patch/list.rs
+++ b/radicle-cli/src/commands/patch/list.rs
@@ -86,11 +86,11 @@ fn print(
                 term::format::dim(format!("R{}", patch.version())).into(),
             ])
             .space()
-            .extend(common::pretty_commit_version(&revision.oid, workdir)?)
+            .extend(common::pretty_commit_version(&revision.head(), workdir)?)
             .space()
             .extend(common::pretty_sync_status(
                 repository.raw(),
-                *revision.oid,
+                revision.head().into(),
                 target_head,
             )?),
         )
@@ -103,14 +103,14 @@ fn print(
         // Don't show an "update" line for the first revision.
         if revision_id != latest {
             timeline.push((
-                revision.timestamp,
+                revision.timestamp(),
                 term::Line::spaced(
                     [
                         term::format::tertiary("↑").into(),
                         term::format::default("updated to").into(),
                         term::format::dim(revision_id).into(),
                         term::format::parens(term::format::secondary(term::format::oid(
-                            revision.oid,
+                            revision.head(),
                         )))
                         .into(),
                     ]
@@ -119,7 +119,7 @@ fn print(
             ));
         }
 
-        for merge in revision.merges.iter() {
+        for merge in revision.merges() {
             let peer = repository.remote(&merge.node)?;
             let mut badges = Vec::new();
 
@@ -144,7 +144,7 @@ fn print(
                 ),
             ));
         }
-        for (reviewer, review) in revision.reviews.iter() {
+        for (reviewer, review) in revision.reviews() {
             let verdict = match review.verdict() {
                 Some(Verdict::Accept) => term::format::positive(term::format::dim("✓ accepted")),
                 Some(Verdict::Reject) => term::format::negative(term::format::dim("✗ rejected")),

--- a/radicle-cli/src/commands/patch/update.rs
+++ b/radicle-cli/src/commands/patch/update.rs
@@ -57,15 +57,15 @@ fn show_update_commit_info(
         term::format::tertiary(term::format::cob(patch_id)),
         term::format::dim(format!("R{current_version}")),
         term::format::parens(term::format::secondary(term::format::oid(
-            current_revision.oid
+            current_revision.head()
         ))),
         term::format::dim(format!("R{}", current_version + 1)),
-        term::format::parens(term::format::secondary(term::format::oid(*head_oid))),
+        term::format::parens(term::format::secondary(term::format::oid(head_oid))),
     );
 
     // Difference between the two revisions.
     let head_oid = branch_oid(head_branch)?;
-    term::patch::print_commits_ahead_behind(workdir, *head_oid, *current_revision.oid)?;
+    term::patch::print_commits_ahead_behind(workdir, *head_oid, *current_revision.head())?;
 
     Ok(())
 }
@@ -97,7 +97,7 @@ pub fn run(
 
     // TODO(cloudhead): Handle error.
     let (_, current_revision) = patch.latest().unwrap();
-    if *current_revision.oid == *branch_oid(&head_branch)? {
+    if current_revision.head() == branch_oid(&head_branch)? {
         term::info!("Nothing to do, patch is already up to date.");
         return Ok(());
     }

--- a/radicle-httpd/src/api/json.rs
+++ b/radicle-httpd/src/api/json.rs
@@ -121,15 +121,14 @@ pub(crate) fn patch(id: PatchId, patch: Patch, repo: &git::Repository) -> Value 
             json!({
                 "id": id,
                 "description": rev.description(),
-                "base": rev.base,
-                "oid": rev.oid,
-                "refs": get_refs(repo, patch.author().id(), &rev.oid).unwrap_or(vec![]),
+                "base": rev.base(),
+                "oid": rev.head(),
+                "refs": get_refs(repo, patch.author().id(), &rev.head()).unwrap_or(vec![]),
                 "merges": rev.merges().collect::<Vec<_>>(),
-                "discussions": rev.discussion
-                  .comments()
-                  .map(|(id, comment)| Comment::new(id, comment, &rev.discussion))
+                "discussions": rev.discussion().comments()
+                  .map(|(id, comment)| Comment::new(id, comment, rev.discussion()))
                   .collect::<Vec<_>>(),
-                "timestamp": rev.timestamp,
+                "timestamp": rev.timestamp(),
                 "reviews": rev.reviews().collect::<Vec<_>>(),
             })
         }).collect::<Vec<_>>(),


### PR DESCRIPTION
Replaces pub accessors to struct fields with methods.
Also creates some methods to compute necessary information

As talked about here https://github.com/radicle-dev/heartwood/pull/479#issuecomment-1482503388
and here https://github.com/radicle-dev/heartwood/pull/479#issuecomment-1482731408

There are also other places where we eventually could reduce public exposure, but one PR at a time