### PR TITLE
Canonical `refs/rad/id`

### DIFF
--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -326,6 +326,14 @@ fn test_clone() {
         .unwrap();
 
     assert_eq!(oid, *canonical);
+
+    // Make sure that bob has refs/rad/id set
+    assert!(bob
+        .storage
+        .repository(acme)
+        .unwrap()
+        .identity_head()
+        .is_ok());
 }
 
 #[test]

--- a/radicle-node/src/worker.rs
+++ b/radicle-node/src/worker.rs
@@ -328,6 +328,8 @@ impl<G: Signer + Ecdh + 'static> Worker<G> {
             log::debug!(target: "worker", "Fetch for {} exited successfully", rid);
             let head = repo.set_head()?;
             log::debug!(target: "worker", "Head for {} set to {head}", rid);
+            let head = repo.set_identity_head()?;
+            log::debug!(target: "worker", "'refs/rad/id' for {} set to {head}", rid);
             Ok(vec![])
         } else {
             log::error!(target: "worker", "Fetch for {} failed", rid);

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -83,6 +83,7 @@ pub fn init<G: Signer>(
     )?;
     let signed = project.sign_refs(signer)?;
     let _head = project.set_head()?;
+    let _head = project.set_identity_head()?;
 
     Ok((project.id, doc, signed))
 }

--- a/radicle/src/storage.rs
+++ b/radicle/src/storage.rs
@@ -353,6 +353,17 @@ pub trait ReadRepository {
     /// Returns the [`Oid`] as well as the qualified reference name.
     fn canonical_head(&self) -> Result<(Qualified, Oid), IdentityError>;
 
+    /// Get the head of the `rad/id` reference in this repository.
+    ///
+    /// Returns the reference pointed to by `rad/id` if it is set. Otherwise, computes the canonical
+    /// `rad/id` using [`ReadRepository::canonical_identity_head`].
+    fn identity_head(&self) -> Result<Oid, IdentityError>;
+
+    /// Compute the canonical `rad/id` of this repository.
+    ///
+    /// Ignores any existing `rad/id` reference.
+    fn canonical_identity_head(&self) -> Result<Oid, IdentityError>;
+
     /// Get the `reference` for the given `remote`.
     ///
     /// Returns `None` is the reference did not exist.
@@ -403,6 +414,8 @@ pub trait WriteRepository: ReadRepository {
     /// Set the repository head to the canonical branch.
     /// This computes the head based on the delegate set.
     fn set_head(&self) -> Result<Oid, IdentityError>;
+    /// Set the repository 'rad/id' to the canonical commit, agreed by quorum.
+    fn set_identity_head(&self) -> Result<Oid, IdentityError>;
     /// Sign the repository's refs under the `refs/rad/sigrefs` branch.
     fn sign_refs<G: Signer>(&self, signer: &G) -> Result<SignedRefs<Verified>, Error>;
     /// Get the underlying git repository.

--- a/radicle/src/test/storage.rs
+++ b/radicle/src/test/storage.rs
@@ -194,6 +194,14 @@ impl ReadRepository for MockRepository {
     ) -> Result<(Oid, crate::identity::Doc<crate::crypto::Unverified>), IdentityError> {
         Ok((git2::Oid::zero().into(), self.doc.clone().unverified()))
     }
+
+    fn identity_head(&self) -> Result<Oid, IdentityError> {
+        todo!()
+    }
+
+    fn canonical_identity_head(&self) -> Result<Oid, IdentityError> {
+        todo!()
+    }
 }
 
 impl WriteRepository for MockRepository {
@@ -209,6 +217,10 @@ impl WriteRepository for MockRepository {
         &self,
         _signer: &G,
     ) -> Result<crate::storage::refs::SignedRefs<Verified>, Error> {
+        todo!()
+    }
+
+    fn set_identity_head(&self) -> Result<Oid, IdentityError> {
         todo!()
     }
 }


### PR DESCRIPTION
Introduce a canonical reference for refs/rad/id to aid in discovering
information about a repository without knowing a peer -- e.g. if a
peer wants to clone a new repository it needs to find out which peers
are delegates for that project, but does not know what their NIDs are
up front.

The approach mirrors the canonical `head` for a repository and
introduces useful constructors for `Doc`/`DocAt`.