### PR TITLE
Print the version only, without the name or commit hash

### DIFF
--- a/radicle-cli/src/main.rs
+++ b/radicle-cli/src/main.rs
@@ -66,12 +66,12 @@ fn print_version() {
     if VERSION.contains("-dev") {
         println!("{NAME} {VERSION}+{GIT_HEAD}")
     } else {
-        println!("{NAME} {VERSION} ({GIT_HEAD})")
+        println!("{VERSION}")
     }
 }
 
 fn print_help() -> anyhow::Result<()> {
-    print_version();
+    println!("{NAME} {VERSION} ({GIT_HEAD})")
     println!("{DESCRIPTION}");
     println!();
 


### PR DESCRIPTION
Hey folks :wave:,

I'm the author and maintainer of https://github.com/cytechmobile/radicle-vscode-extension. I came up against a tiny QoL issue with the CLI and thought I'd take a stab at it. Please note, this is the very first time I've ever touched Rust code, let alone contributing to this repo, so please help me double-check that I haven't broken everything! 😅

Before this change, invoking the CLI as `rad --version` would print something like `rad 0.6.1 (ae07b6f)`. Notice that the output is not valid [semver](https://semver.org/) because it contains the `rad ` substring preceding the actual version number and the ` (ae07b6f)` succeeding it.

Because of this, clients of the CLI that want to interpolate the CLI version in a composed string e.g.:

```js
const log = `Using rad CLI v${getRadCliVersion()} from ${getRadCliPath()}`
```

will end up with the following as a result:

`Using rad CLI vrad 0.6.1 (ae07b6f) from /usr/bin/rad`

Note how we wanted to have `v0.6.1` and instead have `vrad 0.6.1 (ae07b6f)`.

This commit fixes the above issue for the specific command `rad --version` while taking care that there are no side-effects to the output of other other existing commands.

Note also that the commit hash can still be shown when printing help.

If this PR makes no sense or is undesired in terms of product perspective, please direct me towards corrections or just close it altogether, no worries. :)