### PR TITLE
node: fetch trusted peers on clone

### DIFF
--- a/radicle-node/src/service/tracking.rs
+++ b/radicle-node/src/service/tracking.rs
@@ -131,7 +131,7 @@ impl Config {
                         // trusted and delegate remotes.
                         Ok(Namespaces::All)
                     } else {
-                        Ok(Namespaces::Many(trusted))
+                        Ok(Namespaces::Trusted(trusted))
                     }
                 }
             },

--- a/radicle-node/src/test/simulator.rs
+++ b/radicle-node/src/test/simulator.rs
@@ -671,7 +671,7 @@ fn fetch<W: WriteRepository>(
     let namespace = match namespaces.into() {
         Namespaces::All => None,
         Namespaces::One(ns) => Some(ns),
-        Namespaces::Many(ns) => Some(ns.head),
+        Namespaces::Many(trusted) => trusted.into_iter().next(),
     };
     let mut updates = Vec::new();
     let mut callbacks = git::RemoteCallbacks::new();

--- a/radicle-node/src/test/simulator.rs
+++ b/radicle-node/src/test/simulator.rs
@@ -670,8 +670,7 @@ fn fetch<W: WriteRepository>(
 ) -> Result<Vec<RefUpdate>, radicle::storage::FetchError> {
     let namespace = match namespaces.into() {
         Namespaces::All => None,
-        Namespaces::One(ns) => Some(ns),
-        Namespaces::Many(trusted) => trusted.into_iter().next(),
+        Namespaces::Trusted(trusted) => trusted.into_iter().next(),
     };
     let mut updates = Vec::new();
     let mut callbacks = git::RemoteCallbacks::new();

--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -321,20 +321,6 @@ fn test_fetch_trusted_remotes() {
         .unwrap()
         .collect::<Result<HashSet<_>, _>>()
         .unwrap();
-    assert_eq!(bob_remotes, Some(alice.id).into_iter().collect());
-
-    // TODO(finto): we have to fetch again to get the other trusted remotes.
-    // At the moment, the existing Namespaces enum does not allow us
-    // to pass on what nodes are tracked, if there is no existing
-    // repository. Thus, the first fetch only attempts to clone the
-    // delegate.
-    bob.handle.fetch(acme, alice.id).unwrap();
-    assert!(result.is_success());
-    let bob_remotes = bob_repo
-        .remote_ids()
-        .unwrap()
-        .collect::<Result<HashSet<_>, _>>()
-        .unwrap();
 
     assert!(bob_remotes.len() == trusted.len() + 1);
     assert!(bob_remotes.is_superset(&trusted));

--- a/radicle-node/src/worker/fetch/refspecs.rs
+++ b/radicle-node/src/worker/fetch/refspecs.rs
@@ -54,8 +54,7 @@ impl AsRefspecs for SpecialRefs {
                     },
                 ]
             }
-            Namespaces::One(pk) => rad_refs(pk),
-            Namespaces::Many(pks) => pks.iter().flat_map(rad_refs).collect(),
+            Namespaces::Trusted(pks) => pks.iter().flat_map(rad_refs).collect(),
         }
     }
 
@@ -106,15 +105,7 @@ impl AsRefspecs for Namespaces {
                 dst: (*storage::git::NAMESPACES_GLOB).clone(),
                 force: false,
             }],
-            Namespaces::One(pk) => {
-                let ns = pk.to_namespace().with_pattern(git::refspec::STAR);
-                vec![Refspec {
-                    src: ns.clone(),
-                    dst: ns,
-                    force: false,
-                }]
-            }
-            Namespaces::Many(pks) => pks
+            Namespaces::Trusted(pks) => pks
                 .iter()
                 .map(|pk| {
                     let ns = pk.to_namespace().with_pattern(git::refspec::STAR);

--- a/radicle/src/storage.rs
+++ b/radicle/src/storage.rs
@@ -34,15 +34,13 @@ pub enum Namespaces {
     /// All namespaces.
     #[default]
     All,
-    /// A single namespace, by public key.
-    One(PublicKey),
-    /// Many namespaces, by public keys.
-    Many(HashSet<PublicKey>),
+    /// The trusted set of namespaces.
+    Trusted(HashSet<PublicKey>),
 }
 
-impl From<PublicKey> for Namespaces {
-    fn from(pk: PublicKey) -> Self {
-        Self::One(pk)
+impl FromIterator<PublicKey> for Namespaces {
+    fn from_iter<T: IntoIterator<Item = PublicKey>>(iter: T) -> Self {
+        Self::Trusted(iter.into_iter().collect())
     }
 }
 

--- a/radicle/src/storage.rs
+++ b/radicle/src/storage.rs
@@ -1,7 +1,7 @@
 pub mod git;
 pub mod refs;
 
-use std::collections::hash_map;
+use std::collections::{hash_map, HashSet};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{fmt, io};
@@ -37,47 +37,12 @@ pub enum Namespaces {
     /// A single namespace, by public key.
     One(PublicKey),
     /// Many namespaces, by public keys.
-    Many(NonEmpty<PublicKey>),
-}
-
-impl Namespaces {
-    pub fn remotes<R>(repo: &R) -> Result<Option<Self>, refs::Error>
-    where
-        R: ReadRepository,
-    {
-        Ok(NonEmpty::collect(repo.remotes()?.keys().copied()).map(Self::Many))
-    }
-
-    pub fn delegates<R>(repo: &R) -> Result<Self, IdentityError>
-    where
-        R: ReadRepository,
-    {
-        Ok(Self::Many(repo.delegates()?.map(PublicKey::from)))
-    }
-
-    pub fn as_fetchspecs(&self) -> Vec<String> {
-        match self {
-            Self::All => vec![String::from("refs/namespaces/*:refs/namespaces/*")],
-            Self::One(pk) => vec![format!(
-                "refs/namespaces/{pk}/refs/*:refs/namespaces/{pk}/refs/*"
-            )],
-            Self::Many(pks) => pks
-                .iter()
-                .map(|pk| format!("refs/namespaces/{pk}/refs/*:refs/namespaces/{pk}/refs/*"))
-                .collect(),
-        }
-    }
+    Many(HashSet<PublicKey>),
 }
 
 impl From<PublicKey> for Namespaces {
     fn from(pk: PublicKey) -> Self {
         Self::One(pk)
-    }
-}
-
-impl From<NonEmpty<PublicKey>> for Namespaces {
-    fn from(pks: NonEmpty<PublicKey>) -> Self {
-        Self::Many(pks)
     }
 }
 


### PR DESCRIPTION
When a repository does not yet exist during a fetch, i.e. a clone, then only delegates are being fetched.

Augment Namespaces::Many to hold the trusted and optional delegate peers separately. Doing so allows the construction of the variant without the repository existing, but tracking relationships existing.

This variant can then be used to build refspecs for both the trusted peers and delegates when doing a cloning fetch.