### PR TITLE
radicle: force new or initial construction of LWWReg

### DIFF
--- a/radicle-crdt/src/lwwreg.rs
+++ b/radicle-crdt/src/lwwreg.rs
@@ -14,6 +14,16 @@ pub struct LWWReg<T, C = clock::Lamport> {
 }
 
 impl<T: Semilattice, C: PartialOrd> LWWReg<T, C> {
+    pub fn initial(value: T) -> Self
+    where
+        C: Default,
+    {
+        Self {
+            clock: Max::from(C::default()),
+            value,
+        }
+    }
+
     pub fn new(value: T, clock: C) -> Self {
         Self {
             clock: Max::from(clock),
@@ -43,15 +53,6 @@ impl<T: Semilattice, C: PartialOrd> LWWReg<T, C> {
 
     pub fn into_inner(self) -> (T, C) {
         (self.value, self.clock.into_inner())
-    }
-}
-
-impl<T, C: Default> From<T> for LWWReg<T, C> {
-    fn from(value: T) -> Self {
-        Self {
-            clock: Max::from(C::default()),
-            value,
-        }
     }
 }
 

--- a/radicle/src/cob/identity.rs
+++ b/radicle/src/cob/identity.rs
@@ -167,9 +167,9 @@ impl Semilattice for Proposal {
 impl Default for Proposal {
     fn default() -> Self {
         Self {
-            title: Max::from(String::default()).into(),
-            description: Max::from(String::default()).into(),
-            state: Max::from(State::default()).into(),
+            title: LWWReg::initial(Max::from(String::default())),
+            description: LWWReg::initial(Max::from(String::default())),
+            state: LWWReg::initial(Max::from(State::default())),
             revisions: GMap::default(),
             timeline: GSet::default(),
         }

--- a/radicle/src/cob/issue.rs
+++ b/radicle/src/cob/issue.rs
@@ -83,9 +83,9 @@ pub struct Issue {
     /// Actors assigned to this issue.
     assignees: LWWSet<ActorId>,
     /// Title of the issue.
-    title: LWWReg<Max<String>, clock::Lamport>,
+    title: LWWReg<Max<String>>,
     /// Current state of the issue.
-    state: LWWReg<Max<State>, clock::Lamport>,
+    state: LWWReg<Max<State>>,
     /// Associated tags.
     tags: LWWSet<Tag>,
     /// Discussion around this issue.
@@ -106,8 +106,8 @@ impl Default for Issue {
     fn default() -> Self {
         Self {
             assignees: LWWSet::default(),
-            title: Max::from(String::default()).into(),
-            state: Max::from(State::default()).into(),
+            title: LWWReg::initial(Max::from(String::default())),
+            state: LWWReg::initial(Max::from(State::default())),
             tags: LWWSet::default(),
             thread: Thread::default(),
         }


### PR DESCRIPTION
Using LWWReg::from will always set the clock value to the default, which can end up being used wrong.

Instead, introduce a constructor method `initial` to indicate that it should be used on initial construction, while `new` should be used for newer values of the register.

Fixes #496 