### PR TITLE
radicle: simplify patch.latest()

### DIFF
--- a/radicle-cli/src/commands/patch/checkout.rs
+++ b/radicle-cli/src/commands/patch/checkout.rs
@@ -53,9 +53,7 @@ fn find_patch_commit<'a>(
         Ok(commit) => Ok(commit),
         Err(e) if git::ext::is_not_found_err(&e) => {
             // TODO: Handle case of concurrent revisions.
-            let (_, rev) = patch
-                .latest()
-                .ok_or(anyhow!("patch does not have any revisions"))?;
+            let (_, rev) = patch.latest();
             let author = **rev.author.id();
             let remote = stored.remote(&author)?;
 

--- a/radicle-cli/src/commands/patch/common.rs
+++ b/radicle-cli/src/commands/patch/common.rs
@@ -183,7 +183,7 @@ pub fn find_unmerged_with_base(
     let mut matches = Vec::new();
 
     for (id, patch, clock) in proposed {
-        let (_, rev) = patch.latest().unwrap();
+        let (_, rev) = patch.latest();
 
         if !rev.merges.is_empty() {
             continue;

--- a/radicle-cli/src/commands/patch/list.rs
+++ b/radicle-cli/src/commands/patch/list.rs
@@ -1,5 +1,3 @@
-use anyhow::anyhow;
-
 use radicle::cob::patch::{Patch, PatchId, Patches, Verdict};
 use radicle::git;
 use radicle::prelude::*;
@@ -75,9 +73,7 @@ fn print(
         &patch.timestamp(),
     )));
 
-    let (latest, revision) = patch
-        .latest()
-        .ok_or_else(|| anyhow!("patch is malformed: no revisions found"))?;
+    let (latest, revision) = patch.latest();
     let mut widget = term::VStack::default()
         .child(
             term::Line::spaced([

--- a/radicle-cli/src/commands/patch/update.rs
+++ b/radicle-cli/src/commands/patch/update.rs
@@ -96,7 +96,7 @@ pub fn run(
     };
 
     // TODO(cloudhead): Handle error.
-    let (_, current_revision) = patch.latest().unwrap();
+    let (_, current_revision) = patch.latest();
     if *current_revision.oid == *branch_oid(&head_branch)? {
         term::info!("Nothing to do, patch is already up to date.");
         return Ok(());


### PR DESCRIPTION
Make patch.latest() simpler unwrapping the Option out of the return type.  A patch is expected to have one or more revisions.  This is reflected in other methods already such as `head()`.