### PR TITLE
Use cached canonical `rad/id` refs

### DIFF
--- a/radicle/src/cob/identity.rs
+++ b/radicle/src/cob/identity.rs
@@ -230,9 +230,12 @@ impl Proposal {
             self.description().unwrap_or_default()
         );
         let current = doc.update(remote, &msg, &signatures.collect::<Vec<_>>(), repo.raw())?;
+        let head = repo.set_identity_head()?;
+
+        assert_eq!(head, current);
 
         Ok(Identity {
-            head: current,
+            head,
             root: previous.root,
             current,
             revision: previous.revision + 1,

--- a/radicle/src/rad.rs
+++ b/radicle/src/rad.rs
@@ -165,7 +165,6 @@ pub fn fork<G: Signer, S: storage::WriteStorage>(
 ) -> Result<(), ForkError> {
     let me = signer.public_key();
     let repository = storage.repository_mut(rid)?;
-    // TODO: We should get the id branch pointer from a stored canonical reference.
     let (canonical_id, _) = repository.identity_doc()?;
     let (canonical_branch, canonical_head) = repository.head()?;
     let raw = repository.raw();


### PR DESCRIPTION
We were recomputing the `rad/id` ref every time it was accessed.

@FintanH any idea why the `rad-id.md` tests fail? Seems like there's some discrepancy between the cached and canonical ref, which makes me think we aren't setting the ref in some crucial place during `rad id`?