### PR TITLE
tui: Introduce view pages

### DIFF
--- a/radicle-tui/src/lib.rs
+++ b/radicle-tui/src/lib.rs
@@ -8,6 +8,7 @@ use tuirealm::Frame;
 use tuirealm::{Application, EventListenerCfg, NoUserEvent};
 
 pub mod cob;
+pub mod subs;
 pub mod ui;
 
 /// Trait that must be implemented by client applications in order to be run

--- a/radicle-tui/src/subs.rs
+++ b/radicle-tui/src/subs.rs
@@ -1,0 +1,32 @@
+use std::hash::Hash;
+
+use tuirealm::event::{Key, KeyEvent, KeyModifiers};
+use tuirealm::{Sub, SubClause, SubEventClause};
+
+pub fn navigation<Id, UserEvent>() -> Sub<Id, UserEvent>
+where
+    Id: Clone + Hash + Eq + PartialEq,
+    UserEvent: Clone + Eq + PartialEq + PartialOrd,
+{
+    Sub::new(
+        SubEventClause::Keyboard(KeyEvent {
+            code: Key::Tab,
+            modifiers: KeyModifiers::NONE,
+        }),
+        SubClause::Always,
+    )
+}
+
+pub fn global<Id, UserEvent>() -> Sub<Id, UserEvent>
+where
+    Id: Clone + Hash + Eq + PartialEq,
+    UserEvent: Clone + Eq + PartialEq + PartialOrd,
+{
+    Sub::new(
+        SubEventClause::Keyboard(KeyEvent {
+            code: Key::Char('q'),
+            modifiers: KeyModifiers::NONE,
+        }),
+        SubClause::Always,
+    )
+}

--- a/radicle-tui/src/subs.rs
+++ b/radicle-tui/src/subs.rs
@@ -3,30 +3,30 @@ use std::hash::Hash;
 use tuirealm::event::{Key, KeyEvent, KeyModifiers};
 use tuirealm::{Sub, SubClause, SubEventClause};
 
-pub fn navigation<Id, UserEvent>() -> Sub<Id, UserEvent>
+pub fn navigation<Id, UserEvent>() -> Vec<Sub<Id, UserEvent>>
 where
     Id: Clone + Hash + Eq + PartialEq,
     UserEvent: Clone + Eq + PartialEq + PartialOrd,
 {
-    Sub::new(
+    vec![Sub::new(
         SubEventClause::Keyboard(KeyEvent {
             code: Key::Tab,
             modifiers: KeyModifiers::NONE,
         }),
         SubClause::Always,
-    )
+    )]
 }
 
-pub fn global<Id, UserEvent>() -> Sub<Id, UserEvent>
+pub fn global<Id, UserEvent>() -> Vec<Sub<Id, UserEvent>>
 where
     Id: Clone + Hash + Eq + PartialEq,
     UserEvent: Clone + Eq + PartialEq + PartialOrd,
 {
-    Sub::new(
+    vec![Sub::new(
         SubEventClause::Keyboard(KeyEvent {
             code: Key::Char('q'),
             modifiers: KeyModifiers::NONE,
         }),
         SubClause::Always,
-    )
+    )]
 }

--- a/radicle-tui/src/ui/theme.rs
+++ b/radicle-tui/src/ui/theme.rs
@@ -1,6 +1,6 @@
 use tuirealm::props::Color;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Colors {
     pub default_fg: Color,
     pub tabs_fg: Color,
@@ -20,7 +20,7 @@ pub struct Colors {
     pub browser_patch_list_timestamp: Color,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Icons {
     pub property_divider: char,
     pub shortcutbar_divider: char,
@@ -42,7 +42,7 @@ pub struct Icons {
 ///         "shortcuts.divider: "∙",
 ///     }
 /// }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Theme {
     pub name: String,
     pub colors: Colors,


### PR DESCRIPTION
**Rationale**

`tuirealm`'s event and prop system is designed to work with flat component hierarchies. Building deep nested component hierarchies would need a lot more additional effort to properly pass events and props down these hierarchies. This makes it hard to implement full app views (home, patch details etc) as components. 

**Implementation**

This introduces view pages that take into account the flat component hierarchies, and provide switchable sets of components. 