### PR TITLE
tui: UX improvements

### DIFF
--- a/radicle-tui/src/app.rs
+++ b/radicle-tui/src/app.rs
@@ -14,7 +14,9 @@ use radicle_tui::ui;
 use radicle_tui::ui::components::container::{GlobalListener, LabeledContainer, Tabs};
 use radicle_tui::ui::components::context::{ContextBar, Shortcuts};
 use radicle_tui::ui::components::list::PropertyList;
-use radicle_tui::ui::components::workspace::{Browser, IssueBrowser, PatchActivity, PatchFiles};
+use radicle_tui::ui::components::workspace::{
+    Browser, Dashboard, IssueBrowser, PatchActivity, PatchFiles,
+};
 use radicle_tui::ui::layout;
 use radicle_tui::ui::theme::{self, Theme};
 use radicle_tui::ui::widget::Widget;
@@ -425,6 +427,12 @@ impl tuirealm::Component<Message, NoUserEvent> for Widget<Browser<(PatchId, Patc
             },
             _ => None,
         }
+    }
+}
+
+impl tuirealm::Component<Message, NoUserEvent> for Widget<Dashboard> {
+    fn on(&mut self, _event: Event<NoUserEvent>) -> Option<Message> {
+        None
     }
 }
 

--- a/radicle-tui/src/app.rs
+++ b/radicle-tui/src/app.rs
@@ -16,7 +16,7 @@ use radicle_tui::ui;
 use radicle_tui::ui::components::container::{GlobalListener, LabeledContainer, Tabs};
 use radicle_tui::ui::components::context::{ContextBar, Shortcuts};
 use radicle_tui::ui::components::list::PropertyList;
-use radicle_tui::ui::components::workspace::{Browser, PatchActivity, PatchFiles};
+use radicle_tui::ui::components::workspace::{Browser, IssueBrowser, PatchActivity, PatchFiles};
 use radicle_tui::ui::layout;
 use radicle_tui::ui::theme::{self, Theme};
 use radicle_tui::ui::widget::Widget;
@@ -230,7 +230,7 @@ impl ViewPage for Home {
         let navigation = ui::home_navigation(theme).to_boxed();
 
         let dashboard = ui::dashboard(theme, &context.id, &context.project).to_boxed();
-        let issue_browser = Box::<Phantom>::default();
+        let issue_browser = ui::issue_browser(&theme).to_boxed();
         let patch_browser = ui::patch_browser(theme, &context.patches, &context.profile).to_boxed();
 
         let shortcuts = ui::shortcuts(
@@ -427,6 +427,12 @@ impl tuirealm::Component<Message, NoUserEvent> for Widget<Browser<(PatchId, Patc
             },
             _ => None,
         }
+    }
+}
+
+impl tuirealm::Component<Message, NoUserEvent> for Widget<IssueBrowser> {
+    fn on(&mut self, _event: Event<NoUserEvent>) -> Option<Message> {
+        None
     }
 }
 

--- a/radicle-tui/src/ui.rs
+++ b/radicle-tui/src/ui.rs
@@ -22,7 +22,7 @@ use widget::Widget;
 use self::cob::patch;
 use self::components::context::ContextBar;
 use self::components::list::{List, Table};
-use self::components::workspace::{Browser, IssueBrowser, PatchActivity, PatchFiles};
+use self::components::workspace::{Browser, Dashboard, IssueBrowser, PatchActivity, PatchFiles};
 use self::theme::Theme;
 
 pub fn global_listener() -> Widget<GlobalListener> {
@@ -212,8 +212,8 @@ pub fn patch_navigation(theme: &theme::Theme) -> Widget<Tabs> {
     tabs(theme, vec![label("activity"), label("files")])
 }
 
-pub fn dashboard(theme: &theme::Theme, id: &Id, project: &Project) -> Widget<LabeledContainer> {
-    labeled_container(
+pub fn dashboard(theme: &theme::Theme, id: &Id, project: &Project) -> Widget<Dashboard> {
+    let about = labeled_container(
         theme,
         "about",
         property_list(
@@ -225,5 +225,8 @@ pub fn dashboard(theme: &theme::Theme, id: &Id, project: &Project) -> Widget<Lab
             ],
         )
         .to_boxed(),
-    )
+    );
+    let dashboard = Dashboard::new(about);
+
+    Widget::new(dashboard)
 }

--- a/radicle-tui/src/ui.rs
+++ b/radicle-tui/src/ui.rs
@@ -122,8 +122,16 @@ pub fn table(theme: &theme::Theme, items: &[impl List], profile: &Profile) -> Wi
 }
 
 pub fn issue_browser(theme: &theme::Theme) -> Widget<IssueBrowser> {
+    let shortcuts = shortcuts(
+        theme,
+        vec![
+            shortcut(theme, "tab", "section"),
+            shortcut(theme, "q", "quit"),
+        ],
+    );
+
     let not_implemented = label("not implemented").foreground(theme.colors.default_fg);
-    let browser = IssueBrowser::new(not_implemented);
+    let browser = IssueBrowser::new(not_implemented, shortcuts);
 
     Widget::new(browser)
 }
@@ -133,6 +141,16 @@ pub fn patch_browser(
     items: &[(PatchId, Patch)],
     profile: &Profile,
 ) -> Widget<Browser<(PatchId, Patch)>> {
+    let shortcuts = shortcuts(
+        theme,
+        vec![
+            shortcut(theme, "tab", "section"),
+            shortcut(theme, "↑/↓", "navigate"),
+            shortcut(theme, "enter", "show"),
+            shortcut(theme, "q", "quit"),
+        ],
+    );
+
     let widths = AttrValue::Payload(PropPayload::Vec(vec![
         PropValue::U16(2),
         PropValue::U16(43),
@@ -153,21 +171,51 @@ pub fn patch_browser(
     let table = table(theme, items, profile)
         .custom("widths", widths)
         .custom("header", header);
-    let browser: Browser<(PatchId, Patch)> = Browser::new(table);
+    let browser: Browser<(PatchId, Patch)> = Browser::new(table, shortcuts);
 
     Widget::new(browser)
 }
 
-pub fn patch_activity(theme: &theme::Theme) -> Widget<PatchActivity> {
+pub fn patch_activity(
+    theme: &theme::Theme,
+    patch: (PatchId, &Patch),
+    profile: &Profile,
+) -> Widget<PatchActivity> {
+    let (id, patch) = patch;
+    let shortcuts = shortcuts(
+        theme,
+        vec![
+            shortcut(theme, "esc", "back"),
+            shortcut(theme, "tab", "section"),
+            shortcut(theme, "q", "quit"),
+        ],
+    );
+    let context = patch_context(theme, (id, patch), profile);
+
     let not_implemented = label("not implemented").foreground(theme.colors.default_fg);
-    let activity = PatchActivity::new(not_implemented);
+    let activity = PatchActivity::new(not_implemented, context, shortcuts);
 
     Widget::new(activity)
 }
 
-pub fn patch_files(theme: &theme::Theme) -> Widget<PatchFiles> {
+pub fn patch_files(
+    theme: &theme::Theme,
+    patch: (PatchId, &Patch),
+    profile: &Profile,
+) -> Widget<PatchFiles> {
+    let (id, patch) = patch;
+    let shortcuts = shortcuts(
+        theme,
+        vec![
+            shortcut(theme, "esc", "back"),
+            shortcut(theme, "tab", "section"),
+            shortcut(theme, "q", "quit"),
+        ],
+    );
+    let context = patch_context(theme, (id, patch), profile);
+
     let not_implemented = label("not implemented").foreground(theme.colors.default_fg);
-    let files = PatchFiles::new(not_implemented);
+    let files = PatchFiles::new(not_implemented, context, shortcuts);
 
     Widget::new(files)
 }
@@ -198,7 +246,7 @@ pub fn patch_context(
         .background(Color::Rgb(50, 50, 50));
 
     let context_bar = ContextBar::new(context, id, author, title, comments);
-    Widget::new(context_bar)
+    Widget::new(context_bar).height(1)
 }
 
 pub fn home_navigation(theme: &theme::Theme) -> Widget<Tabs> {
@@ -226,7 +274,14 @@ pub fn dashboard(theme: &theme::Theme, id: &Id, project: &Project) -> Widget<Das
         )
         .to_boxed(),
     );
-    let dashboard = Dashboard::new(about);
+    let shortcuts = shortcuts(
+        theme,
+        vec![
+            shortcut(theme, "tab", "section"),
+            shortcut(theme, "q", "quit"),
+        ],
+    );
+    let dashboard = Dashboard::new(about, shortcuts);
 
     Widget::new(dashboard)
 }

--- a/radicle-tui/src/ui.rs
+++ b/radicle-tui/src/ui.rs
@@ -22,7 +22,7 @@ use widget::Widget;
 use self::cob::patch;
 use self::components::context::ContextBar;
 use self::components::list::{List, Table};
-use self::components::workspace::{Browser, PatchActivity, PatchFiles};
+use self::components::workspace::{Browser, IssueBrowser, PatchActivity, PatchFiles};
 use self::theme::Theme;
 
 pub fn global_listener() -> Widget<GlobalListener> {
@@ -119,6 +119,13 @@ pub fn table(theme: &theme::Theme, items: &[impl List], profile: &Profile) -> Wi
         .content(AttrValue::Table(items))
         .background(theme.colors.labeled_container_bg)
         .highlight(theme.colors.item_list_highlighted_bg)
+}
+
+pub fn issue_browser(theme: &theme::Theme) -> Widget<IssueBrowser> {
+    let not_implemented = label("not implemented").foreground(theme.colors.default_fg);
+    let browser = IssueBrowser::new(not_implemented);
+
+    Widget::new(browser)
 }
 
 pub fn patch_browser(

--- a/radicle-tui/src/ui/components/workspace.rs
+++ b/radicle-tui/src/ui/components/workspace.rs
@@ -8,6 +8,7 @@ use tuirealm::{AttrValue, Attribute, Frame, MockComponent, State};
 use crate::ui::layout;
 use crate::ui::widget::{Widget, WidgetComponent};
 
+use super::container::LabeledContainer;
 use super::label::Label;
 use super::list::{List, Table};
 
@@ -44,9 +45,37 @@ impl<T: List> WidgetComponent for Browser<T> {
     }
 }
 
+pub struct Dashboard {
+    about: Widget<LabeledContainer>,
+}
+impl Dashboard {
+    pub fn new(about: Widget<LabeledContainer>) -> Self {
+        Self { about }
+    }
+}
+
+impl WidgetComponent for Dashboard {
+    fn view(&mut self, _properties: &Props, frame: &mut Frame, area: Rect) {
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Length(4)].as_ref())
+            .split(area);
+        self.about.view(frame, layout[0]);
+    }
+
+    fn state(&self) -> State {
+        State::None
+    }
+
+    fn perform(&mut self, _properties: &Props, _cmd: Cmd) -> CmdResult {
+        CmdResult::None
+    }
+}
+
 pub struct IssueBrowser {
     label: Widget<Label>,
 }
+
 impl IssueBrowser {
     pub fn new(label: Widget<Label>) -> Self {
         Self { label }

--- a/radicle-tui/src/ui/components/workspace.rs
+++ b/radicle-tui/src/ui/components/workspace.rs
@@ -44,6 +44,36 @@ impl<T: List> WidgetComponent for Browser<T> {
     }
 }
 
+pub struct IssueBrowser {
+    label: Widget<Label>,
+}
+impl IssueBrowser {
+    pub fn new(label: Widget<Label>) -> Self {
+        Self { label }
+    }
+}
+
+impl WidgetComponent for IssueBrowser {
+    fn view(&mut self, _properties: &Props, frame: &mut Frame, area: Rect) {
+        let label_w = self
+            .label
+            .query(Attribute::Width)
+            .unwrap_or(AttrValue::Size(1))
+            .unwrap_size();
+        let rect = layout::centered_label(label_w, area);
+
+        self.label.view(frame, rect);
+    }
+
+    fn state(&self) -> State {
+        State::None
+    }
+
+    fn perform(&mut self, _properties: &Props, _cmd: Cmd) -> CmdResult {
+        CmdResult::None
+    }
+}
+
 pub struct PatchActivity {
     label: Widget<Label>,
 }

--- a/radicle-tui/src/ui/components/workspace.rs
+++ b/radicle-tui/src/ui/components/workspace.rs
@@ -2,25 +2,28 @@ use std::marker::PhantomData;
 
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::props::Props;
-use tuirealm::tui::layout::{Constraint, Direction, Layout, Rect};
+use tuirealm::tui::layout::Rect;
 use tuirealm::{AttrValue, Attribute, Frame, MockComponent, State};
 
 use crate::ui::layout;
 use crate::ui::widget::{Widget, WidgetComponent};
 
 use super::container::LabeledContainer;
+use super::context::{ContextBar, Shortcuts};
 use super::label::Label;
 use super::list::{List, Table};
 
 pub struct Browser<T> {
     list: Widget<Table>,
+    shortcuts: Widget<Shortcuts>,
     phantom: PhantomData<T>,
 }
 
 impl<T: List> Browser<T> {
-    pub fn new(list: Widget<Table>) -> Self {
+    pub fn new(list: Widget<Table>, shortcuts: Widget<Shortcuts>) -> Self {
         Self {
             list,
+            shortcuts,
             phantom: PhantomData,
         }
     }
@@ -28,12 +31,15 @@ impl<T: List> Browser<T> {
 
 impl<T: List> WidgetComponent for Browser<T> {
     fn view(&mut self, _properties: &Props, frame: &mut Frame, area: Rect) {
-        let layout = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(vec![Constraint::Min(1)].as_ref())
-            .split(area);
+        let shortcuts_h = self
+            .shortcuts
+            .query(Attribute::Height)
+            .unwrap_or(AttrValue::Size(0))
+            .unwrap_size();
+        let layout = layout::root_component(area, shortcuts_h);
 
         self.list.view(frame, layout[0]);
+        self.shortcuts.view(frame, layout[1]);
     }
 
     fn state(&self) -> State {
@@ -47,20 +53,25 @@ impl<T: List> WidgetComponent for Browser<T> {
 
 pub struct Dashboard {
     about: Widget<LabeledContainer>,
+    shortcuts: Widget<Shortcuts>,
 }
 impl Dashboard {
-    pub fn new(about: Widget<LabeledContainer>) -> Self {
-        Self { about }
+    pub fn new(about: Widget<LabeledContainer>, shortcuts: Widget<Shortcuts>) -> Self {
+        Self { about, shortcuts }
     }
 }
 
 impl WidgetComponent for Dashboard {
     fn view(&mut self, _properties: &Props, frame: &mut Frame, area: Rect) {
-        let layout = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(vec![Constraint::Length(4)].as_ref())
-            .split(area);
+        let shortcuts_h = self
+            .shortcuts
+            .query(Attribute::Height)
+            .unwrap_or(AttrValue::Size(0))
+            .unwrap_size();
+        let layout = layout::root_component(area, shortcuts_h);
+
         self.about.view(frame, layout[0]);
+        self.shortcuts.view(frame, layout[1]);
     }
 
     fn state(&self) -> State {
@@ -74,11 +85,12 @@ impl WidgetComponent for Dashboard {
 
 pub struct IssueBrowser {
     label: Widget<Label>,
+    shortcuts: Widget<Shortcuts>,
 }
 
 impl IssueBrowser {
-    pub fn new(label: Widget<Label>) -> Self {
-        Self { label }
+    pub fn new(label: Widget<Label>, shortcuts: Widget<Shortcuts>) -> Self {
+        Self { label, shortcuts }
     }
 }
 
@@ -89,9 +101,16 @@ impl WidgetComponent for IssueBrowser {
             .query(Attribute::Width)
             .unwrap_or(AttrValue::Size(1))
             .unwrap_size();
-        let rect = layout::centered_label(label_w, area);
+        let shortcuts_h = self
+            .shortcuts
+            .query(Attribute::Height)
+            .unwrap_or(AttrValue::Size(0))
+            .unwrap_size();
+        let layout = layout::root_component(area, shortcuts_h);
 
-        self.label.view(frame, rect);
+        self.label
+            .view(frame, layout::centered_label(label_w, layout[0]));
+        self.shortcuts.view(frame, layout[1])
     }
 
     fn state(&self) -> State {
@@ -105,11 +124,21 @@ impl WidgetComponent for IssueBrowser {
 
 pub struct PatchActivity {
     label: Widget<Label>,
+    context: Widget<ContextBar>,
+    shortcuts: Widget<Shortcuts>,
 }
 
 impl PatchActivity {
-    pub fn new(label: Widget<Label>) -> Self {
-        Self { label }
+    pub fn new(
+        label: Widget<Label>,
+        context: Widget<ContextBar>,
+        shortcuts: Widget<Shortcuts>,
+    ) -> Self {
+        Self {
+            label,
+            context,
+            shortcuts,
+        }
     }
 }
 
@@ -120,9 +149,22 @@ impl WidgetComponent for PatchActivity {
             .query(Attribute::Width)
             .unwrap_or(AttrValue::Size(1))
             .unwrap_size();
-        let rect = layout::centered_label(label_w, area);
+        let context_h = self
+            .context
+            .query(Attribute::Height)
+            .unwrap_or(AttrValue::Size(0))
+            .unwrap_size();
+        let shortcuts_h = self
+            .shortcuts
+            .query(Attribute::Height)
+            .unwrap_or(AttrValue::Size(0))
+            .unwrap_size();
+        let layout = layout::root_component_with_context(area, context_h, shortcuts_h);
 
-        self.label.view(frame, rect);
+        self.label
+            .view(frame, layout::centered_label(label_w, layout[0]));
+        self.context.view(frame, layout[1]);
+        self.shortcuts.view(frame, layout[2]);
     }
 
     fn state(&self) -> State {
@@ -136,11 +178,21 @@ impl WidgetComponent for PatchActivity {
 
 pub struct PatchFiles {
     label: Widget<Label>,
+    context: Widget<ContextBar>,
+    shortcuts: Widget<Shortcuts>,
 }
 
 impl PatchFiles {
-    pub fn new(label: Widget<Label>) -> Self {
-        Self { label }
+    pub fn new(
+        label: Widget<Label>,
+        context: Widget<ContextBar>,
+        shortcuts: Widget<Shortcuts>,
+    ) -> Self {
+        Self {
+            label,
+            context,
+            shortcuts,
+        }
     }
 }
 
@@ -151,9 +203,22 @@ impl WidgetComponent for PatchFiles {
             .query(Attribute::Width)
             .unwrap_or(AttrValue::Size(1))
             .unwrap_size();
-        let rect = layout::centered_label(label_w, area);
+        let context_h = self
+            .context
+            .query(Attribute::Height)
+            .unwrap_or(AttrValue::Size(0))
+            .unwrap_size();
+        let shortcuts_h = self
+            .shortcuts
+            .query(Attribute::Height)
+            .unwrap_or(AttrValue::Size(0))
+            .unwrap_size();
+        let layout = layout::root_component_with_context(area, context_h, shortcuts_h);
 
-        self.label.view(frame, rect);
+        self.label
+            .view(frame, layout::centered_label(label_w, layout[0]));
+        self.context.view(frame, layout[1]);
+        self.shortcuts.view(frame, layout[2]);
     }
 
     fn state(&self) -> State {

--- a/radicle-tui/src/ui/layout.rs
+++ b/radicle-tui/src/ui/layout.rs
@@ -46,18 +46,24 @@ pub fn h_stack(
     widgets.into_iter().zip(layout.into_iter()).collect()
 }
 
-pub fn default_page(area: Rect, nav_h: u16, shortcuts_h: u16) -> Vec<Rect> {
+pub fn default_page(area: Rect, nav_h: u16) -> Vec<Rect> {
     let margin_h = 1u16;
-    let content_h = area
-        .height
-        .saturating_sub(shortcuts_h.saturating_add(nav_h).saturating_add(margin_h));
+    let content_h = area.height.saturating_sub(nav_h.saturating_add(margin_h));
 
     Layout::default()
         .direction(Direction::Vertical)
         .horizontal_margin(margin_h)
+        .constraints([Constraint::Length(nav_h), Constraint::Length(content_h)].as_ref())
+        .split(area)
+}
+
+pub fn root_component(area: Rect, shortcuts_h: u16) -> Vec<Rect> {
+    let content_h = area.height.saturating_sub(shortcuts_h);
+
+    Layout::default()
+        .direction(Direction::Vertical)
         .constraints(
             [
-                Constraint::Length(nav_h),
                 Constraint::Length(content_h),
                 Constraint::Length(shortcuts_h),
             ]
@@ -66,21 +72,15 @@ pub fn default_page(area: Rect, nav_h: u16, shortcuts_h: u16) -> Vec<Rect> {
         .split(area)
 }
 
-pub fn page_with_context(area: Rect, nav_h: u16, context_h: u16, shortcuts_h: u16) -> Vec<Rect> {
-    let margin_h = 1u16;
-    let content_h = area.height.saturating_sub(
-        shortcuts_h
-            .saturating_add(nav_h)
-            .saturating_add(context_h)
-            .saturating_add(margin_h),
-    );
+pub fn root_component_with_context(area: Rect, context_h: u16, shortcuts_h: u16) -> Vec<Rect> {
+    let content_h = area
+        .height
+        .saturating_sub(shortcuts_h.saturating_add(context_h));
 
     Layout::default()
         .direction(Direction::Vertical)
-        .horizontal_margin(margin_h)
         .constraints(
             [
-                Constraint::Length(nav_h),
                 Constraint::Length(content_h),
                 Constraint::Length(context_h),
                 Constraint::Length(shortcuts_h),


### PR DESCRIPTION
- add a `not implemented` placeholder label to the `issues` tab
- bring back initial message polling (`PollStrategy::Once`), but only re-render UI if needed
- move shortcuts widget to root widget (e.g. dashboard, patch browser etc.) in order to show widget-dependent shortcuts

![image](https://user-images.githubusercontent.com/20012009/232993062-a30deaae-0222-43f3-a361-21ce2b1fd54d.png)

![image](https://user-images.githubusercontent.com/20012009/232993219-e17b5830-8ddf-48ae-bbe2-16b31c313803.png)

