### PR TITLE
radicle: Describe local URL components

### DIFF
--- a/radicle/src/storage/git/transport/local/url.rs
+++ b/radicle/src/storage/git/transport/local/url.rs
@@ -35,6 +35,7 @@ pub enum UrlError {
 ///
 /// `rad://<repo>[/<namespace>]`
 ///
+/// Where 'repo' is the `repository`s RID and 'namespace' is the `node`s NID.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Url {
     /// Repository identifier.

--- a/radicle/src/storage/git/transport/local/url.rs
+++ b/radicle/src/storage/git/transport/local/url.rs
@@ -33,9 +33,9 @@ pub enum UrlError {
 /// * Used to content-address a repository, eg. when sharing projects.
 /// * Used as a remore url in a git working copy.
 ///
-/// `rad://<repo>[/<namespace>]`
+/// `rad://<resource>[/<pubkey>]`
 ///
-/// Where 'repo' is the `Repository`s RID and 'namespace' is the `Node`s NID.
+/// Where 'resource' is the `Repository`s RID and 'pubkey' is the Node (or Peer) ID.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Url {
     /// Repository identifier.

--- a/radicle/src/storage/git/transport/local/url.rs
+++ b/radicle/src/storage/git/transport/local/url.rs
@@ -35,7 +35,7 @@ pub enum UrlError {
 ///
 /// `rad://<repo>[/<namespace>]`
 ///
-/// Where 'repo' is the `repository`s RID and 'namespace' is the `node`s NID.
+/// Where 'repo' is the `Repository`s RID and 'namespace' is the `Node`s NID.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Url {
     /// Repository identifier.


### PR DESCRIPTION
Make it clear to developers what the 'url's `repo` and `namepace` components are.  The RIP defines how a Radicle URL should be used, so lets reflect it in the documentation.

 https://github.com/radicle-dev/rips/blob/d301f209d688e45ee6d5da7fd1d6daab6b865ebf/0003-storage-layout.md#url