### PR TITLE
node: ensure that we can fetch with a non-existent tracked node

### DIFF
--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -417,6 +417,35 @@ fn test_fetch_trusted_remotes() {
 }
 
 #[test]
+fn test_missing_remote() {
+    logger::init(log::Level::Debug);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mut alice = Node::init(tmp.path());
+    let bob = Node::init(tmp.path());
+    let acme = alice.project("acme", "");
+
+    let mut alice = alice.spawn(service::Config::default());
+    let mut bob = bob.spawn(service::Config::default());
+    let carol = MockSigner::default();
+
+    alice.connect(&bob);
+    converge([&alice, &bob]);
+
+    assert!(bob.handle.track_repo(acme, Scope::Trusted).unwrap());
+    assert!(bob.handle.track_node(*carol.public_key(), None).unwrap());
+    let result = bob.handle.fetch(acme, alice.id).unwrap();
+    assert!(result.is_success());
+    log::debug!(target: "test", "Fetch complete with {}", bob.id);
+    rad::fork_remote(acme, &alice.id, &carol, &bob.storage).unwrap();
+
+    alice.issue(acme, "Missing Remote", "Fixing the missing remote issue");
+    let result = bob.handle.fetch(acme, alice.id).unwrap();
+    assert!(result.is_success());
+    log::debug!(target: "test", "Fetch complete with {}", bob.id);
+}
+
+#[test]
 fn test_fetch_preserve_owned_refs() {
     logger::init(log::Level::Debug);
 

--- a/radicle-node/src/tests/e2e.rs
+++ b/radicle-node/src/tests/e2e.rs
@@ -734,3 +734,82 @@ fn test_connection_crossing() {
 
     assert!(s1 ^ s2, "Exactly one session should be established");
 }
+
+// Note to self look into missing updates on force push
+#[test]
+fn test_outdated_sigrefs() {
+    logger::init(log::Level::Debug);
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut alice = Node::init(tmp.path());
+    let bob = Node::init(tmp.path());
+    let eve = Node::init(tmp.path());
+
+    let rid = alice.project("acme", "");
+
+    let mut alice = alice.spawn(service::Config::default());
+    let mut bob = bob.spawn(service::Config::default());
+    let mut eve = eve.spawn(service::Config::default());
+
+    bob.handle.track_repo(rid, Scope::All).unwrap();
+    eve.handle.track_repo(rid, Scope::All).unwrap();
+    alice.connect(&bob);
+    bob.connect(&eve);
+    eve.connect(&alice);
+    converge([&alice, &bob, &eve]);
+
+    bob.handle.fetch(rid, alice.id).unwrap();
+    assert!(bob.storage.contains(&rid).unwrap());
+    rad::fork(rid, &bob.signer, &bob.storage).unwrap();
+
+    eve.handle.fetch(rid, alice.id).unwrap();
+    assert!(eve.storage.contains(&rid).unwrap());
+    rad::fork(rid, &eve.signer, &eve.storage).unwrap();
+
+    alice
+        .handle
+        .track_node(eve.id, Some("eve".to_string()))
+        .unwrap();
+    alice.handle.fetch(rid, eve.id).unwrap();
+    let repo = alice.storage.repository(rid).unwrap();
+    assert!(repo.remote(&eve.id).is_ok());
+
+    bob.handle.fetch(rid, eve.id).unwrap();
+    let repo = bob.storage.repository(rid).unwrap();
+    let eve_remote = repo.remote(&eve.id).unwrap();
+    let old_refs = eve_remote.refs;
+
+    // At this stage, Alice and Bob have Eve's fork and Eve does not
+    // have Bob's fork
+
+    eve.issue(
+        rid,
+        "Outdated Sigrefs",
+        "Outdated sigrefs are harshing my vibes",
+    );
+    let repo = eve.storage.repository(rid).unwrap();
+    let eves_refs = repo.remote(&eve.id).unwrap().refs;
+
+    // Get the current state of eve's refs in alice's storage
+    alice.handle.fetch(rid, eve.id).unwrap();
+    let repo = alice.storage.repository(rid).unwrap();
+    let eve_remote = repo.remote(&eve.id).unwrap();
+    let eves_refs_expected = eve_remote.refs;
+    assert_ne!(eves_refs_expected, old_refs);
+    assert_eq!(eves_refs_expected, eves_refs);
+
+    alice
+        .handle
+        .track_node(bob.id, Some("bob".to_string()))
+        .unwrap();
+    alice.handle.fetch(rid, bob.id).unwrap();
+
+    // Ensure that bob's refs have not changed
+    let repo = alice.storage.repository(rid).unwrap();
+    let eve_remote = repo.remote(&eve.id).unwrap();
+    let eves_refs = eve_remote.refs;
+
+    assert_ne!(eves_refs, old_refs);
+    assert_eq!(eves_refs_expected, eves_refs);
+}

--- a/radicle-node/src/worker/fetch.rs
+++ b/radicle-node/src/worker/fetch.rs
@@ -398,6 +398,16 @@ impl<'a> StagingPhaseFinal<'a> {
         let head = production.set_identity_head()?;
         log::debug!(target: "worker", "'refs/rad/id' for {} set to {head}", production.id);
 
+        #[cfg(test)]
+        // N.b. This is to prevent us from shooting ourselves in the
+        // foot with storage inconsistencies.
+        radicle::debug_assert_matches!(
+            production.validate(),
+            Ok(()),
+            "repository {} is not valid",
+            production.id,
+        );
+
         Ok((updates, remotes))
     }
 


### PR DESCRIPTION
Ensure that non-existent tracking relationships do not affect fetching.

This is tested by first performing a clone, by `bob` from `alice`, after `bob` tracks a remote that does not exist. `alice` creates an issue which is then fetched by `bob` -- to ensure the fetching scenario is also tested.
