### PR TITLE
cli: reduce `rad ls` dependency

### DIFF
--- a/radicle-cli/src/commands/ls.rs
+++ b/radicle-cli/src/commands/ls.rs
@@ -48,10 +48,11 @@ pub fn run(_options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let storage = &profile.storage;
     let mut table = term::Table::default();
 
-    storage.repositories()?.into_iter().for_each(|id| {
-        let Ok(repo) = storage.repository(id) else { return };
-        let Ok((_, head)) = repo.head() else { return };
-        let Ok(proj) = repo.project_of(profile.id()) else { return };
+    for id in storage.repositories()? {
+        let Ok(repo) = storage.repository(id) else { continue };
+        let Ok((_, head)) = repo.head() else { continue };
+        let Ok(proj) = repo.project() else { continue };
+
         let head = term::format::oid(head);
         table.push([
             term::format::bold(proj.name().to_owned()),
@@ -59,7 +60,7 @@ pub fn run(_options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
             term::format::secondary(head),
             term::format::italic(proj.description().to_owned()),
         ]);
-    });
+    }
     table.print();
 
     Ok(())

--- a/radicle/src/storage/git.rs
+++ b/radicle/src/storage/git.rs
@@ -300,9 +300,11 @@ impl Repository {
         Identity::load_at(head, self)
     }
 
-    pub fn project_of(&self, remote: &RemoteId) -> Result<Project, IdentityError> {
-        let doc = self.identity_doc_of(remote)?;
-        let proj = doc.project()?;
+    /// Get the canonical project information.
+    pub fn project(&self) -> Result<Project, IdentityError> {
+        let head = self.identity_head()?;
+        let doc = self.identity_doc_at(head)?;
+        let proj = doc.verified()?.project()?;
 
         Ok(proj)
     }


### PR DESCRIPTION
Fetch project information using the canonical head.  This avoids expecting a user's fork to exist locally.