### PR TITLE
cli: add rad fork command

### DIFF
--- a/radicle-cli/examples/rad-fetch.md
+++ b/radicle-cli/examples/rad-fetch.md
@@ -1,0 +1,27 @@
+Using `rad clone` is useful if we want to create and fetch a project
+that exists on Radicle, but perhaps we're in a scenario where we may
+already have an existing Git repository and so a full clone is not
+necessary.
+
+Instead, we want to fetch the project from the network into our local
+storage. In this scenario, we know that the project is
+`rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji`. In order to fetch it, we first
+have to track the project.
+
+```
+$ rad track rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+✓ Tracking policy updated for rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji with scope 'trusted'
+! Warning: fetch after track is not yet supported
+```
+
+Now that the project is tracked we can fetch it and we will have it in
+our local storage.
+
+```
+$ rad fetch rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+✓ Fetching rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji from z6MknSL…StBU8Vi..
+✓ Fetched repository from 1 seed(s)
+```
+
+However, we don't have a local fork of the project. We can follow this
+up with [rad-fork][rad-fork.md].

--- a/radicle-cli/examples/rad-fork.md
+++ b/radicle-cli/examples/rad-fork.md
@@ -1,0 +1,49 @@
+If we have fetched a project, then we do not have a fork of the
+repository in the storage, i.e. there is no ref hierarchy for our
+NID. This is demonstrated below where our NID is
+`z6Mkt67GdsW7715MEfRuP4pSZxJRJh6kj6Y48WRqVv4N1tRk`:
+
+```
+$ rad inspect rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji --refs
+.
+`-- z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+    `-- refs
+        |-- heads
+        |   `-- master
+        `-- rad
+            |-- id
+            `-- sigrefs
+```
+
+To remedy this, we can use the `rad fork` command for the project we
+wish to fork:
+
+```
+$ rad fork rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
+✓ Forked project rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji for z6Mkt67GdsW7715MEfRuP4pSZxJRJh6kj6Y48WRqVv4N1tRk
+```
+
+Now, if we `rad inspect` the project's refs again we will see that we
+have a copy of the main set of refs:
+
+```
+$ rad inspect rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji --refs
+.
+|-- z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
+|   `-- refs
+|       |-- heads
+|       |   `-- master
+|       `-- rad
+|           |-- id
+|           `-- sigrefs
+`-- z6Mkt67GdsW7715MEfRuP4pSZxJRJh6kj6Y48WRqVv4N1tRk
+    `-- refs
+        |-- heads
+        |   `-- master
+        `-- rad
+            |-- id
+            `-- sigrefs
+```
+
+We are now able to setup a remote in our own working copy of the
+project and push to our own fork.

--- a/radicle-cli/src/commands.rs
+++ b/radicle-cli/src/commands.rs
@@ -14,6 +14,8 @@ pub mod rad_delegate;
 pub mod rad_edit;
 #[path = "commands/fetch.rs"]
 pub mod rad_fetch;
+#[path = "commands/fork.rs"]
+pub mod rad_fork;
 #[path = "commands/help.rs"]
 pub mod rad_help;
 #[path = "commands/id.rs"]

--- a/radicle-cli/src/commands/fork.rs
+++ b/radicle-cli/src/commands/fork.rs
@@ -1,0 +1,74 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+use anyhow::Context as _;
+
+use radicle::prelude::Id;
+use radicle::rad;
+
+use crate::terminal as term;
+use crate::terminal::args;
+use crate::terminal::args::{Args, Error, Help};
+
+pub const HELP: Help = Help {
+    name: "ls",
+    description: "Create a fork of a project",
+    version: env!("CARGO_PKG_VERSION"),
+    usage: r#"
+Usage
+
+    rad fork [<rid>] [<option>...]
+
+Options
+
+    --help          Print help
+"#,
+};
+
+pub struct Options {
+    rid: Option<Id>,
+}
+
+impl Args for Options {
+    fn from_args(args: Vec<OsString>) -> anyhow::Result<(Self, Vec<OsString>)> {
+        use lexopt::prelude::*;
+
+        let mut parser = lexopt::Parser::from_args(args);
+        let mut rid = None;
+
+        if let Some(arg) = parser.next()? {
+            match arg {
+                Long("help") => {
+                    return Err(Error::Help.into());
+                }
+                Value(val) if rid.is_none() => {
+                    rid = Some(args::rid(&val)?);
+                }
+                _ => return Err(anyhow::anyhow!(arg.unexpected())),
+            }
+        }
+
+        Ok((Options { rid }, vec![]))
+    }
+}
+
+pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
+    let profile = ctx.profile()?;
+    let signer = profile.signer()?;
+    let storage = &profile.storage;
+
+    let rid = match options.rid {
+        Some(rid) => rid,
+        None => {
+            let (_, rid) = radicle::rad::repo(Path::new("."))
+                .context("Current directory is not a radicle project")?;
+
+            rid
+        }
+    };
+
+    rad::fork(rid, &signer, &storage)?;
+    term::success!("Forked project {rid} for {}", profile.id());
+
+    Ok(())
+}

--- a/radicle-cli/src/commands/help.rs
+++ b/radicle-cli/src/commands/help.rs
@@ -19,6 +19,7 @@ const COMMANDS: &[Help] = &[
     rad_clone::HELP,
     rad_edit::HELP,
     rad_fetch::HELP,
+    rad_fork::HELP,
     rad_help::HELP,
     rad_id::HELP,
     rad_init::HELP,

--- a/radicle-cli/src/commands/inspect.rs
+++ b/radicle-cli/src/commands/inspect.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context as _};
 use chrono::prelude::*;
 use json_color::{Color, Colorizer};
 
-use radicle::crypto::Unverified;
+use radicle::crypto::{Unverified, Verified};
 use radicle::identity::Untrusted;
 use radicle::identity::{Doc, Id};
 use radicle::storage::{ReadRepository, ReadStorage};
@@ -120,9 +120,10 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let profile = ctx.profile()?;
     let storage = &profile.storage;
     let signer = term::signer(&profile)?;
-    let project = storage
-        .get(signer.public_key(), id)?
+    let repo = storage
+        .repository(id)
         .context("No project with the given RID exists")?;
+    let project = Doc::<Verified>::canonical(&repo)?;
 
     match options.target {
         Target::Refs => {

--- a/radicle-cli/src/main.rs
+++ b/radicle-cli/src/main.rs
@@ -171,6 +171,14 @@ fn run_other(exe: &str, args: &[OsString]) -> Result<(), Option<anyhow::Error>> 
                 args.to_vec(),
             );
         }
+        "fork" => {
+            term::run_command_args::<rad_fork::Options, _>(
+                rad_fork::HELP,
+                "Fork",
+                rad_fork::run,
+                args.to_vec(),
+            );
+        }
         "help" => {
             term::run_command_args::<rad_help::Options, _>(
                 rad_help::HELP,

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -429,6 +429,47 @@ fn rad_fetch() {
 }
 
 #[test]
+fn rad_fork() {
+    let mut environment = Environment::new();
+    let working = environment.tmp().join("working");
+    let alice = environment.node("alice");
+    let bob = environment.node("bob");
+
+    let mut alice = alice.spawn(Config::default());
+    let bob = bob.spawn(Config::default());
+
+    alice.connect(&bob);
+    fixtures::repository(working.join("alice"));
+
+    // Alice initializes a repo after her node has started, and after bob has connected to it.
+    test(
+        "examples/rad-init-sync.md",
+        &working.join("alice"),
+        Some(&alice.home),
+        [],
+    )
+    .unwrap();
+
+    // Wait for bob to get any updates to the routing table.
+    bob.converge([&alice]);
+
+    test(
+        "examples/rad-fetch.md",
+        working.join("bob"),
+        Some(&bob.home),
+        [],
+    )
+    .unwrap();
+    test(
+        "examples/rad-fork.md",
+        working.join("bob"),
+        Some(&bob.home),
+        [],
+    )
+    .unwrap();
+}
+
+#[test]
 // User tries to clone; no seeds are available, but user has the repo locally.
 fn test_clone_without_seeds() {
     logger::init(log::Level::Debug);

--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -395,6 +395,40 @@ fn rad_init_sync_and_clone() {
 }
 
 #[test]
+fn rad_fetch() {
+    let mut environment = Environment::new();
+    let working = environment.tmp().join("working");
+    let alice = environment.node("alice");
+    let bob = environment.node("bob");
+
+    let mut alice = alice.spawn(Config::default());
+    let bob = bob.spawn(Config::default());
+
+    alice.connect(&bob);
+    fixtures::repository(working.join("alice"));
+
+    // Alice initializes a repo after her node has started, and after bob has connected to it.
+    test(
+        "examples/rad-init-sync.md",
+        &working.join("alice"),
+        Some(&alice.home),
+        [],
+    )
+    .unwrap();
+
+    // Wait for bob to get any updates to the routing table.
+    bob.converge([&alice]);
+
+    test(
+        "examples/rad-fetch.md",
+        working.join("bob"),
+        Some(&bob.home),
+        [],
+    )
+    .unwrap();
+}
+
+#[test]
 // User tries to clone; no seeds are available, but user has the repo locally.
 fn test_clone_without_seeds() {
     logger::init(log::Level::Debug);


### PR DESCRIPTION
Add a `rad fork` command to create a forked namespace, using the local peer, for the given repository.