### PR TITLE
cli: add verbose flag to rad ls

### DIFF
--- a/radicle-cli/src/commands/ls.rs
+++ b/radicle-cli/src/commands/ls.rs
@@ -18,40 +18,69 @@ Usage
 
 Options
 
-    --help    Print help
+    --versbose, -v  Verbose output
+    --help          Print help
 "#,
 };
 
-pub struct Options {}
+pub struct Options {
+    verbose: bool,
+}
 
 impl Args for Options {
     fn from_args(args: Vec<OsString>) -> anyhow::Result<(Self, Vec<OsString>)> {
         use lexopt::prelude::*;
 
         let mut parser = lexopt::Parser::from_args(args);
+        let mut verbose = false;
 
         if let Some(arg) = parser.next()? {
             match arg {
                 Long("help") => {
                     return Err(Error::Help.into());
                 }
+                Long("verbose") | Short('v') => verbose = true,
                 _ => return Err(anyhow::anyhow!(arg.unexpected())),
             }
         }
 
-        Ok((Options {}, vec![]))
+        Ok((Options { verbose }, vec![]))
     }
 }
 
-pub fn run(_options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
+pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let profile = ctx.profile()?;
     let storage = &profile.storage;
     let mut table = term::Table::default();
 
     storage.repositories()?.into_iter().for_each(|id| {
-        let Ok(repo) = storage.repository(id) else { return };
-        let Ok((_, head)) = repo.head() else { return };
-        let Ok(proj) = repo.project_of(profile.id()) else { return };
+        let repo = match storage.repository(id) {
+            Ok(repo) => repo,
+            Err(err) => {
+                if options.verbose {
+                    term::warning(&format!("failed to load project '{id}': {err}"));
+                }
+                return;
+            }
+        };
+        let head = match repo.head() {
+            Ok((_, head)) => head,
+            Err(err) => {
+                if options.verbose {
+                    term::warning(&format!("failed to get head of project '{id}': {err}"));
+                }
+                return;
+            }
+        };
+        let proj = match repo.project_of(profile.id()) {
+            Ok(proj) => proj,
+            Err(err) => {
+                if options.verbose {
+                    term::warning(&format!("failed to get local project '{id}': {err}"));
+                }
+                return;
+            }
+        };
         let head = term::format::oid(head);
         table.push([
             term::format::bold(proj.name().to_owned()),


### PR DESCRIPTION
A repository may fail to load when trying to run `rad ls`, but the failure will be hidden from the output.

Add a `--verbose` flag to add warning information to stdout when a repository fails to load.
