### PR TITLE
radicle-httpd: Add cob state to listing endpoints

### DIFF
--- a/radicle/src/cob/patch.rs
+++ b/radicle/src/cob/patch.rs
@@ -530,6 +530,20 @@ pub enum State {
     Merged,
 }
 
+impl FromStr for State {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "open" => Ok(Self::Open),
+            "draft" => Ok(Self::Draft),
+            "merged" => Ok(Self::Merged),
+            "archived" => Ok(Self::Archived),
+            _ => Err("Unrecognised patch state"),
+        }
+    }
+}
+
 impl fmt::Display for State {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
This commit adds the cob state of either patches or issues to the corresponding endpoint querystring

So we can either query a cob listing with the required state or expect the default state.
And once filtered by cob state we paginate.