### PR TITLE
cli: allow to force push on a remote

### DIFF
--- a/radicle-cli/src/commands/patch.rs
+++ b/radicle-cli/src/commands/patch.rs
@@ -164,7 +164,7 @@ impl Args for Options {
                     push = false;
                 }
 
-                // Show options.
+                 // Show options.
                 Long("patch") | Short('p') if op == Some(OperationName::Show) => {
                     diff = true;
                 }

--- a/radicle-cli/src/commands/patch/common.rs
+++ b/radicle-cli/src/commands/patch/common.rs
@@ -153,10 +153,10 @@ pub fn push_to_storage(
         }
 
         let output = match head_branch.upstream() {
-            Ok(_) => git::run::<_, _, &str, &str>(Path::new("."), ["push", "rad"], [])?,
+            Ok(_) => git::run::<_, _, &str, &str>(Path::new("."), ["push", "rad", "--force"], [])?,
             Err(_) => git::run::<_, _, &str, &str>(
                 Path::new("."),
-                ["push", "--set-upstream", "rad", branch_name(head_branch)?],
+                ["push", "--set-upstream", "rad", branch_name(head_branch)?, "--force"],
                 [],
             )?,
         };


### PR DESCRIPTION
The are cases where we need to perform a force push on a patch update, so these commits allow passing this information from the command line.

A possible use case is when you rework the git history with some core review and then you want to force push it.

At the current moment, the command fails!