### PR TITLE
Avoid failing `rad-auth` when ssh-agent is not running

### DIFF
--- a/radicle-cli/src/commands/auth.rs
+++ b/radicle-cli/src/commands/auth.rs
@@ -116,7 +116,13 @@ pub fn init(options: Options) -> anyhow::Result<()> {
 }
 
 pub fn authenticate(profile: &Profile, options: Options) -> anyhow::Result<()> {
-    let agent = ssh::agent::Agent::connect()?;
+    let agent = match ssh::agent::Agent::connect() {
+        Err(ssh::agent::Error::EnvVar("SSH_AUTH_SOCK")) => {
+            term::warning("Authenticating without SSH Agent...");
+            return Ok(());
+        }
+        v => v,
+    }?;
 
     // TODO: Only show this if we're not authenticated.
     term::headline(format!(

--- a/radicle-cli/src/commands/auth.rs
+++ b/radicle-cli/src/commands/auth.rs
@@ -154,7 +154,9 @@ pub fn authenticate(profile: &Profile, options: Options) -> anyhow::Result<()> {
             term::passphrase(RAD_PASSPHRASE)
         }?;
         let spinner = term::spinner("Unlocking...");
-        let mut agent = connect_ssh_agent()?.unwrap();
+        let Some(mut agent) = connect_ssh_agent()? else {
+            anyhow::bail!("SSH agent unexpectedly stopped running");
+        };
         register(&mut agent, profile, passphrase)?;
         spinner.finish();
 


### PR DESCRIPTION
Allow `rad-auth` to run without failing when SSH Agent is not running.  In this case we warn the user ssh-agent is not running, and continue to verify with RAD_PASSPHRASE.