### PR TITLE
rad-patch: Fix patch open/upate when out-of-sync

### DIFF
--- a/radicle-cli/src/commands/merge.rs
+++ b/radicle-cli/src/commands/merge.rs
@@ -179,17 +179,8 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
         .find_annotated_commit(revision.head().into())
         .or_else(|e| match e.code() {
             git::raw::ErrorCode::NotFound => {
-                // Avoid using git2 until 'rad://' supports fetching using an Oid as a refspec.
-                crate::git::git(
-                    repo.path(),
-                    [
-                        "fetch",
-                        &git::Url::from(id)
-                            .with_namespace(**patch.author().id())
-                            .to_string(),
-                        &revision.head().to_string(),
-                    ],
-                )?;
+                let url = git::Url::from(id).with_namespace(**patch.author().id());
+                crate::git::anonymous_fetch(&repo, &url, &revision.head())?;
                 let c = repo.find_annotated_commit(revision.head().into())?;
                 Ok(c)
             }

--- a/radicle-cli/src/commands/patch/common.rs
+++ b/radicle-cli/src/commands/patch/common.rs
@@ -37,9 +37,10 @@ fn get_branch(git_ref: git::Qualified) -> git::RefString {
     std::iter::once(head).chain(tail).collect()
 }
 
-/// Determine the merge target for this patch. This can ben any tracked remote's "default"
-/// branch, as well as your own (eg. `rad/master`).
+/// Determine the merge target for this patch. This can be any tracked remote's "default" branch,
+/// as well as your own (eg. `rad/master`).
 pub fn get_merge_target(
+    workdir: &git::raw::Repository,
     storage: &Repository,
     head_branch: &git::raw::Branch,
 ) -> anyhow::Result<(git::RefString, git::Oid)> {
@@ -51,6 +52,7 @@ pub fn get_merge_target(
         anyhow::bail!("commits are already included in the target branch; nothing to do");
     }
 
+    crate::git::anonymous_fetch(workdir, &git::Url::from(storage.id), &target_oid)?;
     Ok((get_branch(qualified_ref), (*target_oid).into()))
 }
 

--- a/radicle-cli/src/commands/patch/create.rs
+++ b/radicle-cli/src/commands/patch/create.rs
@@ -89,7 +89,7 @@ pub fn run(
     let mut patches = patch::Patches::open(storage)?;
     let head_branch = try_branch(workdir.head()?)?;
     push_to_storage(storage, &head_branch, &options)?;
-    let (target_ref, target_oid) = get_merge_target(storage, &head_branch)?;
+    let (target_ref, target_oid) = get_merge_target(workdir, storage, &head_branch)?;
 
     // TODO: Handle case where `rad/master` isn't up to date with the target.
     // In that case we should warn the user that their master branch is not up

--- a/radicle-cli/src/commands/patch/update.rs
+++ b/radicle-cli/src/commands/patch/update.rs
@@ -73,7 +73,7 @@ pub fn run(
 
     push_to_storage(storage, &head_branch, options)?;
 
-    let (_, target_oid) = get_merge_target(storage, &head_branch)?;
+    let (_, target_oid) = get_merge_target(workdir, storage, &head_branch)?;
     let mut patches = patch::Patches::open(storage)?;
 
     let patch_id = match patch_id {

--- a/radicle-cli/src/git.rs
+++ b/radicle-cli/src/git.rs
@@ -101,6 +101,17 @@ impl<'a> TryFrom<git2::Remote<'a>> for Remote<'a> {
     }
 }
 
+/// Helper function to fetch from a git remote by Oid.
+///
+/// Support using Git2 is not yet implemented.
+pub fn anonymous_fetch(workdir: &Repository, endpoint: &git::Url, oid: &Oid) -> anyhow::Result<()> {
+    crate::git::git(
+        workdir.path(),
+        ["fetch", &endpoint.to_string(), &oid.to_string()],
+    )?;
+    Ok(())
+}
+
 /// Get the git repository in the current directory.
 pub fn repository() -> Result<Repository, anyhow::Error> {
     match Repository::open(".") {


### PR DESCRIPTION
Trying to open or update Patch will fail if the user's working copy if out of sync with the Radicle projects canonical path.

Fix this by using an anonymous fetch to import the required commits while avoiding affecting the user's working copy git references.  The approach is already used for `rad-merge`.