### PR TITLE
cli: show the remote in a better table

### DIFF
--- a/1
+++ b/1
@@ -1,0 +1,21 @@
+cli: show a different identifier for the self user
+    
+Show a different identifier in the issue list is a good
+the thing to do just to be able to sort see that there are issue
+assigned to me.
+    
+It is also true that if I see the issue assigned to me
+I can run the `rad issue list --assigned <did>` but I think
+has a string `You` as we did in other places can be nice.
+
+Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# Date:      Sun Apr 23 14:53:25 2023 +0200
+#
+# On branch macros/list-issue-whoami
+# Changes to be committed:
+#	modified:   radicle-cli/src/commands/issue.rs
+#

--- a/radicle-cli/src/commands/remote/list.rs
+++ b/radicle-cli/src/commands/remote/list.rs
@@ -6,13 +6,20 @@ use crate::terminal as term;
 #[inline]
 fn format_direction(d: &git::Direction) -> String {
     match d {
-        git::Direction::Fetch => "fetch".to_owned(),
-        git::Direction::Push => "push".to_owned(),
+        git::Direction::Fetch => "↓".to_owned(),
+        git::Direction::Push => "↑".to_owned(),
     }
 }
 
 pub fn run(repo: &git::Repository) -> anyhow::Result<()> {
-    let mut table = Table::default();
+    let mut table = Table::new(term::table::TableOptions::bordered());
+    table.push([
+        term::format::dim(String::from("●")),
+        term::format::bold(String::from("Name")),
+        term::format::bold(String::from("Node ID")),
+    ]);
+    table.divider();
+
     let remotes = git::rad_remotes(repo)?;
     for r in remotes {
         for spec in r.refspecs() {
@@ -21,11 +28,11 @@ pub fn run(repo: &git::Repository) -> anyhow::Result<()> {
             let name = r.name.clone();
             let nid_row = url.namespace.map_or(
                 term::format::dim("This is the canonical upstream".to_string()),
-                |namespace| term::format::highlight(namespace.to_string()),
+                |namespace| term::format::dim(namespace.to_string()),
             );
             table.push([
-                term::format::badge_positive(format_direction(&dir)),
-                term::format::highlight(name.to_owned()),
+                term::format::tertiary(format_direction(&dir)),
+                term::format::bold(name.to_owned()),
                 nid_row,
             ]);
         }


### PR DESCRIPTION
This change the table in the list remotes to adopt the cli UI unified to list patch, and list issue