### PR TITLE
cli: show a different identifier for the self user

### DIFF
--- a/radicle-cli/src/commands/issue.rs
+++ b/radicle-cli/src/commands/issue.rs
@@ -313,6 +313,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                 Some(Assigned::Peer(id)) => Some(id.into()),
                 None => None,
             };
+            let whoami = profile.id();
 
             let mut t = term::Table::new(term::table::TableOptions::bordered());
             t.push([
@@ -337,7 +338,13 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
 
                 let assigned: String = assigned
                     .iter()
-                    .map(|p| term::format::did(p).to_string())
+                    .map(|p| {
+                        if p.to_string() == whoami.to_string() {
+                            "You".to_string()
+                        } else {
+                            term::format::did(p).to_string()
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .join(", ");
 


### PR DESCRIPTION
Show a different identifier in the issue list is a good the thing to do just to be able to sort see that there are issue assigned to me.

It is also true that if I see the issue assigned to me I can run the `rad issue list --assigned <did>` but I think has a string `You` as we did in other places can be nice.