### PR TITLE
cob: Fix recursion bug in TryFrom call of Reference

### DIFF
--- a/radicle-cob/src/backend/git/change.rs
+++ b/radicle-cob/src/backend/git/change.rs
@@ -137,6 +137,14 @@ impl change::Storage for git2::Repository {
         })
     }
 
+    fn parents_of(&self, id: &Oid) -> Result<Vec<Oid>, Self::LoadError> {
+        Ok(self
+            .find_commit(**id)?
+            .parent_ids()
+            .map(Oid::from)
+            .collect::<Vec<_>>())
+    }
+
     fn load(&self, id: Self::ObjectId) -> Result<Change, Self::LoadError> {
         let commit = Commit::read(self, id.into())?;
         let timestamp = git2::Time::from(commit.committer().time).seconds() as u64;

--- a/radicle-cob/src/change/store.rs
+++ b/radicle-cob/src/change/store.rs
@@ -3,6 +3,7 @@
 use std::{error::Error, fmt};
 
 use nonempty::NonEmpty;
+use radicle_git_ext::Oid;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -37,6 +38,9 @@ pub trait Storage {
         &self,
         id: Self::ObjectId,
     ) -> Result<Change<Self::Parent, Self::ObjectId, Self::Signatures>, Self::LoadError>;
+
+    /// Returns the parents of the object with the specified ID.
+    fn parents_of(&self, id: &Oid) -> Result<Vec<Oid>, Self::LoadError>;
 }
 
 /// Change template, used to create a new change.

--- a/radicle-cob/src/object/storage.rs
+++ b/radicle-cob/src/object/storage.rs
@@ -50,8 +50,6 @@ pub struct Reference {
 pub struct Commit {
     /// The content identifier of the commit.
     pub id: Oid,
-    /// The parents of the commit.
-    pub parents: Vec<Commit>,
 }
 
 pub trait Storage {
@@ -129,10 +127,8 @@ pub mod convert {
 
     impl<'a> From<git2::Commit<'a>> for Commit {
         fn from(commit: git2::Commit<'a>) -> Self {
-            let parents = commit.parents().map(Commit::from).collect();
             Commit {
                 id: commit.id().into(),
-                parents,
             }
         }
     }

--- a/radicle-cob/src/test/storage.rs
+++ b/radicle-cob/src/test/storage.rs
@@ -91,6 +91,15 @@ impl change::Storage for Storage {
     > {
         self.as_raw().load(id)
     }
+
+    fn parents_of(&self, id: &git_ext::Oid) -> Result<Vec<git_ext::Oid>, Self::LoadError> {
+        Ok(self
+            .as_raw()
+            .find_commit(**id)?
+            .parent_ids()
+            .map(git_ext::Oid::from)
+            .collect::<Vec<_>>())
+    }
 }
 
 impl object::Storage for Storage {

--- a/radicle/src/storage/git/cob.rs
+++ b/radicle/src/storage/git/cob.rs
@@ -60,6 +60,10 @@ impl change::Storage for Repository {
     fn load(&self, id: Self::ObjectId) -> Result<cob::Change, Self::LoadError> {
         self.backend.load(id)
     }
+
+    fn parents_of(&self, id: &Oid) -> Result<Vec<Oid>, Self::LoadError> {
+        self.backend.parents_of(id)
+    }
 }
 
 impl cob::object::Storage for Repository {


### PR DESCRIPTION
This commit addresses the issue of recursion in the TryFrom call of Reference by resolving the parent in a lazy way.

Due to constraints posed by the need to access `git2::Repository` or `git2::Commit` to resolve the parent, this commit decides to pull out the parent resolution logic from the `cob::object::Commit` module and move it inside the `cob::store::Store` implementation by adding a new method `parents_of`.

Link: https://radicle.zulipchat.com/#narrow/stream/369277-heartwood/topic/rust.20eats.20RAM.20like.20C
Suggested-by: Fintan Halpenny <fintan.halpenny@gmail.com>
Tested-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>