### PR TITLE
Fix test of rad_sync()

### DIFF
--- a/radicle-cli/tests/commands.rs
+++ b/radicle-cli/tests/commands.rs
@@ -793,6 +793,8 @@ fn rad_sync() {
     alice.connect(&bob);
     eve.connect(&alice);
 
+    thread::sleep(time::Duration::from_millis(30));
+
     bob.routes_to(&[(acme, alice.id)]);
     eve.routes_to(&[(acme, alice.id)]);
     alice.routes_to(&[(acme, alice.id), (acme, eve.id), (acme, bob.id)]);


### PR DESCRIPTION
Hey guys
I'm always running into this issue:
`thread 'rad_sync' panicked at 'Node::routes_to: unexpected route for `
So I've added some lines to radicle-cli/tests/commands.rs to avoid this panic in environment.rs
In environment.rs inside the loop on line 213 I added println for "rid" "nid" and "remaining". This comes out:
```
rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi
{(Id(rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji), PublicKey(z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi))}

rad:z42hL2jL4XNk6K8oHQaSWfMgCL7ji
z6Mkt67GdsW7715MEfRuP4pSZxJRJh6kj6Y48WRqVv4N1tRk
{}
```
So the "remaining"-variable contains one id and pkey pair and I guess it needs two? I am not sure... the 30 ms delays seem to fix this issue, but please verify if this is a viable solution.