### PR TITLE
Use bash from env for better portability

### DIFF
--- a/scripts/import-issue.sh
+++ b/scripts/import-issue.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Import a GitHub issue into Radicle.
 #

--- a/scripts/show-sigrefs.sh
+++ b/scripts/show-sigrefs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "$#" -lt 2 ]; then


### PR DESCRIPTION
Hi
According to [Stackoverflow](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang#10383546) it looks like the portability of the script could be improved by having this new style for the bash shebang.
(Otherwise you might also consider using `#!/bin/sh` ?)