### PR TITLE
Fix linker error on macos 14.3 with nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
           ++ lib.optionals pkgs.stdenv.isDarwin [
             # Additional darwin specific inputs can be set here
             pkgs.libiconv
+            pkgs.darwin.apple_sdk.frameworks.Security
           ];
       };
 


### PR DESCRIPTION
Using nix build resulted in a linker error

ld: framework not found Security

Following the proposed solution in
https://discourse.nixos.org/t/compile-a-rust-binary-on-macos-dbcrossbar/8612 resolves the issue.